### PR TITLE
Init procedure in PCTBgRun

### DIFF
--- a/src/java/com/phenix/pct/PCTBgRun.java
+++ b/src/java/com/phenix/pct/PCTBgRun.java
@@ -543,7 +543,7 @@ public abstract class PCTBgRun extends PCT implements IRunAttributes {
             }
 
             bw.write(MessageFormat.format(this.getProgressProcedures().getRunString(),
-                    escapeString(options.getProcedure())));
+                    escapeString(options.getProcedure()), ""));
 
         } catch (IOException ioe) {
             throw new BuildException(ioe);


### PR DESCRIPTION
Leading to `RUN xxxx.p {1}.` instead of `RUN xxxx.p.`