### PR TITLE
Fix for NPE on DlcHome + PCTCompile

### DIFF
--- a/src/java/com/phenix/pct/CompilationWrapper.java
+++ b/src/java/com/phenix/pct/CompilationWrapper.java
@@ -39,6 +39,7 @@ public class CompilationWrapper extends PCT implements IRunAttributes, ICompilat
     @Override
     public void execute() {
         PCT pctTask;
+        checkDlcHome();
         // Handle pct:compile_ext
         if ("pctcompileext".equalsIgnoreCase(getRuntimeConfigurableWrapper().getElementTag())
                 || "pct:compile_ext"
@@ -60,9 +61,7 @@ public class CompilationWrapper extends PCT implements IRunAttributes, ICompilat
             pctTask.addEnv(var);
         }
         pctTask.bindToOwner(this);
-        if (getDlcHome() != null) {
-            pctTask.setDlcHome(getDlcHome());
-        }
+        pctTask.setDlcHome(getDlcHome());
         pctTask.setIncludedPL(getIncludedPL());
         pctTask.execute();
     }

--- a/src/test/com/phenix/pct/PCTCompileExtTest.java
+++ b/src/test/com/phenix/pct/PCTCompileExtTest.java
@@ -1161,6 +1161,15 @@ public class PCTCompileExtTest extends BuildFileTestNg {
     }
 
     @Test(groups = {"v10"})
+    public void test75() {
+        configureProject(BASEDIR + "test75/build.xml");
+        executeTarget("test");
+
+        File f = new File(BASEDIR + "test75/build/test.r");
+        assertTrue(f.exists());
+    }
+
+    @Test(groups = {"v10"})
     public void test101() {
         configureProject(BASEDIR + "test101/build.xml");
         executeTarget("test");

--- a/src/test/com/phenix/pct/PCTCompileTest.java
+++ b/src/test/com/phenix/pct/PCTCompileTest.java
@@ -1175,4 +1175,14 @@ public class PCTCompileTest extends BuildFileTestNg {
         executeTarget("test");
         assertTrue(new File(BASEDIR + "test74/build/test.r").exists());
     }
+
+    @Test(groups = {"v10"})
+    public void test75() {
+        configureProject(BASEDIR + "test75/build.xml");
+        executeTarget("test");
+
+        File f = new File(BASEDIR + "test75/build/test.r");
+        assertTrue(f.exists());
+    }
+
 }

--- a/tests/PCTCompile/test75/build.xml
+++ b/tests/PCTCompile/test75/build.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<project name="PCTCompile-test75">
+  <taskdef resource="PCT.properties" />
+  <DlcHome value="${DLC}" />
+
+  <target name="test">
+    <mkdir dir="build" />
+    <!-- DLC should be inherited from DlcHome task -->
+    <PCTCompile graphicalMode="false" destDir="build">
+      <fileset dir="src" includes="*.p" />
+      <Profiler enabled="${PROFILER}" coverage="true" outputDir="profiler" />
+    </PCTCompile>
+  </target>
+
+</project>

--- a/tests/PCTCompile/test75/src/test.p
+++ b/tests/PCTCompile/test75/src/test.p
@@ -1,0 +1,2 @@
+MESSAGE "Hello world!".
+RETURN "0".


### PR DESCRIPTION
Global DlcHome task and no dlcHome attribute in PCTCompile leads to NPE