### PR TITLE
Feature PctRcode to check no PCT rcode

### DIFF
--- a/src/java/com/phenix/pct/CompilationAttributes.java
+++ b/src/java/com/phenix/pct/CompilationAttributes.java
@@ -64,6 +64,7 @@ public class CompilationAttributes implements ICompilationAttributes {
     private boolean flattenDbg = true;
     private String ignoredIncludes = null;
     private int fileList = 0;
+    private boolean pctRcode = false;
 
     // Internal use
     private final PCT parent;
@@ -262,6 +263,11 @@ public class CompilationAttributes implements ICompilationAttributes {
         this.fileList = display;
     }
 
+    @Override
+    public void setPctRcode(boolean pctRcode){
+        this.pctRcode = pctRcode;
+    }
+
     public List<ResourceCollection> getResources() {
         return resources;
     }
@@ -400,6 +406,10 @@ public class CompilationAttributes implements ICompilationAttributes {
 
     public int getFileList() {
         return fileList;
+    }
+
+    public boolean isPctRcode(){
+        return pctRcode;
     }
 
     protected void writeCompilationProcedure(File f, Charset c) {

--- a/src/java/com/phenix/pct/CompilationWrapper.java
+++ b/src/java/com/phenix/pct/CompilationWrapper.java
@@ -304,6 +304,11 @@ public class CompilationWrapper extends PCT implements IRunAttributes, ICompilat
     public void setDisplayFiles(int display) {
         compAttributes.setDisplayFiles(display);
     }
+    
+    @Override
+    public void setPctRcode(boolean pctRcode) {
+        compAttributes.setPctRcode(pctRcode);
+    }
 
     // End of ICompilationAttributes methods
     // *************************************

--- a/src/java/com/phenix/pct/ICompilationAttributes.java
+++ b/src/java/com/phenix/pct/ICompilationAttributes.java
@@ -207,4 +207,9 @@ public interface ICompilationAttributes {
      * 1 will display files to be recompiled (and reason). 2 will display all files. 0 doesn't display anything
      */
     void setDisplayFiles(int display);
+
+    /**
+     * Check if existing RCode was build by PCT
+     */
+    void setPctRcode(boolean pctRcode);
 }

--- a/src/java/com/phenix/pct/PCTBgCompile.java
+++ b/src/java/com/phenix/pct/PCTBgCompile.java
@@ -327,7 +327,8 @@ public class PCTBgCompile extends PCTBgRun {
             sb.append(Boolean.toString(compAttrs.isRequireFullKeywords())).append(';');
             sb.append(Boolean.toString(compAttrs.isRequireFullNames())).append(';');
             sb.append(Boolean.toString(compAttrs.isRequireFieldQualifiers())).append(';');
-
+            sb.append(Boolean.toString(compAttrs.isPctRcode())).append(';');
+            
             return sb.toString();
         }
 

--- a/src/java/com/phenix/pct/PCTCompile.java
+++ b/src/java/com/phenix/pct/PCTCompile.java
@@ -238,6 +238,8 @@ public class PCTCompile extends PCTRun {
             bw.newLine();
             bw.write("FILELIST=" + compAttrs.getFileList());
             bw.newLine();
+            bw.write("PCTRCODE=" + (compAttrs.isPctRcode() ? 1 : 0));
+            bw.newLine();
         } catch (IOException ioe) {
             throw new BuildException(Messages.getString("PCTCompile.3"), ioe); //$NON-NLS-1$
         }

--- a/src/progress/pct/compile.p
+++ b/src/progress/pct/compile.p
@@ -71,6 +71,7 @@ FUNCTION CheckIncludes RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT TS AS DATETI
 FUNCTION CheckCRC RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT d AS CHARACTER) FORWARD.
 FUNCTION fileExists RETURNS LOGICAL (INPUT f AS CHARACTER) FORWARD.
 FUNCTION createDir RETURNS LOGICAL (INPUT base AS CHARACTER, INPUT d AS CHARACTER) FORWARD.
+FUNCTION CheckPctRcode RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT TS AS DATETIME, INPUT d AS CHARACTER) FORWARD.
 
 /** Named streams */
 DEFINE STREAM sXref.
@@ -114,6 +115,7 @@ DEFINE VARIABLE cDspSteps AS CHARACTER  NO-UNDO.
 DEFINE VARIABLE cIgnoredIncludes AS CHARACTER  NO-UNDO.
 DEFINE VARIABLE lIgnoredIncludes AS LOGICAL    NO-UNDO.
 DEFINE VARIABLE iFileList AS INTEGER    NO-UNDO.
+DEFINE VARIABLE lPctRcode AS LOGICAL    NO-UNDO INITIAL FALSE.
 
 /* Handle to calling procedure in order to log messages */
 DEFINE VARIABLE hSrcProc AS HANDLE NO-UNDO.
@@ -165,7 +167,8 @@ PROCEDURE setOption.
     WHEN 'FULLNAMES':U        THEN ASSIGN lOptFullNames = (ipValue EQ '1':U).
     WHEN 'FILELIST':U         THEN ASSIGN iFileList = INTEGER(ipValue).
     WHEN 'NUMFILES':U         THEN ASSIGN iTotLines = INTEGER(ipValue).
-
+    WHEN 'PCTRCODE':U         THEN ASSIGN lPctRcode = (ipValue EQ '1':U).
+    
     OTHERWISE RUN logError IN hSrcProc (SUBSTITUTE("Unknown parameter '&1' with value '&2'" ,ipName, ipValue)).
   END CASE.
 
@@ -221,6 +224,7 @@ FUNCTION getRecompileLabel RETURNS CHARACTER (ipVal AS INTEGER):
     WHEN 3 THEN RETURN 'R-code older than include file'.
     WHEN 4 THEN RETURN 'Table CRC'.
     WHEN 5 THEN RETURN 'XCode or force'.
+    WHEN 6 THEN RETURN 'Not a PCT rcode'.
     OTHERWISE   RETURN '???'.
   END.
 END FUNCTION.
@@ -321,6 +325,11 @@ PROCEDURE compileXref.
         ELSE DO:
           IF CheckCRC(ipInFile, PCTDir) THEN DO:
             opComp = 4.
+          END.
+          ELSE DO:
+            IF lPctRcode AND CheckPctRcode (ipInFile, RCodeTS, PCTDir) THEN DO:
+              opComp = 6.
+            END.
           END.
         END.
       END.
@@ -685,6 +694,25 @@ END FUNCTION.
 FUNCTION getTimeStampF RETURNS DATETIME (INPUT f AS CHARACTER):
   ASSIGN FILE-INFO:FILE-NAME = f.
   RETURN DATETIME(FILE-INFO:FILE-MOD-DATE, FILE-INFO:FILE-MOD-TIME * 1000).
+END FUNCTION.
+
+FUNCTION CheckPctRcode RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT ts AS DATETIME, INPUT d AS CHARACTER).
+  
+  FILE-INFO:FILE-NAME = d + '/':U + f + '.inc':U.
+  IF FILE-INFO:FULL-PATHNAME <> ? THEN DO:
+    RETURN (getTimeStampF(FILE-INFO:FULL-PATHNAME) <> ts). 
+  END.
+  FILE-INFO:FILE-NAME = d + '/':U + f + '.crc':U.
+  IF FILE-INFO:FULL-PATHNAME <> ? THEN DO:
+    RETURN (getTimeStampF(FILE-INFO:FULL-PATHNAME) <> ts). 
+  END.
+  FILE-INFO:FILE-NAME = d + '/':U + f + '.xref':U.
+  IF FILE-INFO:FULL-PATHNAME <> ? THEN DO:
+    RETURN (getTimeStampF(FILE-INFO:FULL-PATHNAME) <> ts). 
+  END.
+  
+  RETURN TRUE. /* Default is True */
+
 END FUNCTION.
 
 FUNCTION CheckIncludes RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT ts AS DATETIME, INPUT d AS CHARACTER).

--- a/src/progress/pct/pctBgCompile.p
+++ b/src/progress/pct/pctBgCompile.p
@@ -59,7 +59,7 @@ PROCEDURE setOptions:
     RUN setOption IN hComp ('FULLKW', IF ENTRY(32, ipPrm, ';') EQ 'true' THEN '1' ELSE '0').
     RUN setOption IN hComp ('FULLNAMES', IF ENTRY(33, ipPrm, ';') EQ 'true' THEN '1' ELSE '0').
     RUN setOption IN hComp ('FIELDQLF', IF ENTRY(34, ipPrm, ';') EQ 'true' THEN '1' ELSE '0').
-
+    RUN setOption IN hComp ('PCTRCODE', IF ENTRY(35, ipPrm, ';') EQ 'true' THEN '1' ELSE '0').
     RUN initModule IN hComp.
 
     ASSIGN opOk = TRUE.

--- a/src/test/com/phenix/pct/PCTCompileExtTest.java
+++ b/src/test/com/phenix/pct/PCTCompileExtTest.java
@@ -24,8 +24,10 @@ import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -1167,6 +1169,29 @@ public class PCTCompileExtTest extends BuildFileTestNg {
 
         File f = new File(BASEDIR + "test75/build/test.r");
         assertTrue(f.exists());
+    }
+
+    @Test(groups = {"v10"})
+    public void test76() {
+        configureProject(BASEDIR + "test76/build.xml");
+
+        List<String> rexp = new ArrayList<>();
+        rexp.add(".*");
+        rexp.add("PCTCompile - Progress Code Compiler");
+        rexp.add(Pattern.quote(MessageFormat.format(Messages.getString("PCTCompile.44"), 1)));
+        rexp.add("PCTCompile - Progress Code Compiler");
+        rexp.add(Pattern.quote(MessageFormat.format(Messages.getString("PCTCompile.44"), 0)));
+        expectLogRegexp("test1", rexp, false);
+
+        rexp.clear();
+        rexp.add(".*");
+        rexp.add(".*");
+        rexp.add("PCTCompile - Progress Code Compiler");
+        rexp.add(Pattern.quote(MessageFormat.format(Messages.getString("PCTCompile.44"), 1)));
+        rexp.add(".*");
+        rexp.add("PCTCompile - Progress Code Compiler");
+        rexp.add(Pattern.quote(MessageFormat.format(Messages.getString("PCTCompile.44"), 1)));
+        expectLogRegexp("test2", rexp, false);
     }
 
     @Test(groups = {"v10"})

--- a/src/test/com/phenix/pct/PCTCompileTest.java
+++ b/src/test/com/phenix/pct/PCTCompileTest.java
@@ -1185,4 +1185,27 @@ public class PCTCompileTest extends BuildFileTestNg {
         assertTrue(f.exists());
     }
 
+    @Test(groups = {"v10"})
+    public void test76() {
+        configureProject(BASEDIR + "test76/build.xml");
+
+        List<String> rexp = new ArrayList<>();
+        rexp.add(".*");
+        rexp.add("PCTCompile - Progress Code Compiler");
+        rexp.add("1 file\\(s\\) compiled");
+        rexp.add("PCTCompile - Progress Code Compiler");
+        rexp.add("0 file\\(s\\) compiled");
+        expectLogRegexp("test1", rexp, false);
+        
+        rexp.clear();
+        rexp.add(".*");
+        rexp.add(".*");
+        rexp.add("PCTCompile - Progress Code Compiler");
+        rexp.add("1 file\\(s\\) compiled");
+        rexp.add(".*");
+        rexp.add("PCTCompile - Progress Code Compiler");
+        rexp.add("1 file\\(s\\) compiled");
+        expectLogRegexp("test2", rexp, false);
+    }
+
 }

--- a/tests/PCTCompile/test76/build.xml
+++ b/tests/PCTCompile/test76/build.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<project name="PCTCompile-test76">
+  <taskdef resource="PCT.properties" />
+
+  <target name="test1">
+    <delete dir="build" />
+    <mkdir dir="build" />
+    <PCTCompile graphicalMode="false" destDir="build" dlcHome="${DLC}" failOnError="false">
+      <fileset dir="src" includes="*.p" />
+    </PCTCompile>
+    <sleep seconds="1"/>
+    <PCTCompile graphicalMode="false" destDir="build" dlcHome="${DLC}" failOnError="false" pctRcode="true">
+      <fileset dir="src" includes="*.p" />
+      <Profiler enabled="${PROFILER}" outputDir="profiler" coverage="true" /> 
+    </PCTCompile>
+  </target>
+  
+  <target name="test2">
+    <delete dir="build" />
+    <mkdir dir="build" />
+    <PCTCompile graphicalMode="false" destDir="build" dlcHome="${DLC}" failOnError="false">
+      <fileset dir="src" includes="*.p" />
+    </PCTCompile>
+    <delete file="build/test1.r" />
+    <sleep seconds="1"/>
+    <echo file="build/test1.r" message="fake rcode" />
+    <PCTCompile graphicalMode="false" destDir="build" dlcHome="${DLC}" failOnError="false" pctRcode="true">
+      <fileset dir="src" includes="*.p" />
+      <Profiler enabled="${PROFILER}" outputDir="profiler" coverage="true" /> 
+    </PCTCompile>
+  </target>
+  
+</project>

--- a/tests/PCTCompile/test76/src/test1.p
+++ b/tests/PCTCompile/test76/src/test1.p
@@ -1,0 +1,1 @@
+MESSAGE "Hello world!".


### PR DESCRIPTION
Add a test to control if the rcode was build with pct to prevent
compilation from another way.
It compare the Timstamp of the rcode and the .inc/.crc/.xref.

To use it, you have to set `PctRcode` to true : 
```xml
    <PCTCompile graphicalMode="false" destDir="build" dlcHome="${DLC}" failOnError="false" pctRcode="true">
      <fileset dir="src" includes="*.p" />
    </PCTCompile>
```
