### PR TITLE
Feature tempdir

### DIFF
--- a/src/progress/pct/compile.p
+++ b/src/progress/pct/compile.p
@@ -388,7 +388,9 @@ PROCEDURE compileXref.
 &ENDIF
 
   /* For class, compile in temp dir to avoid parent class rcode */
-  IF cFileExt = ".cls" THEN DO:
+  IF multiComp = TRUE /* true = we probably don't want hierarchie */
+    AND cSaveDir <> ?  /* ? = let OE compile in default dir */
+    AND cFileExt = ".cls" THEN DO:
     cTempDir = "tmpcomp" + STRING(RANDOM ( 0 , 999999 ), "999999" ) + STRING(ETIME).
     lUseTempDir = createDir(SESSION:TEMP-DIRECTORY , cTempDir).
     cTempDir = SESSION:TEMP-DIRECTORY + '/':U + cTempDir.


### PR DESCRIPTION
This PR could be a solution for issue #344

For `.cls` files, I replace the `SaveDir` by a TempDir and I copy only the file I want in the `SaveDir`.
Tempdir is created in the Working directory with a random name.
 
There are 2 exceptions : 
* `multicompile = NO` (Test22) -> in this case, we probably want this behavior
* `DestDir = ?` (Test65) -> in this case, we want the default behavior

For now, I didn't implement any parameters for it, but everything is possible. 