### PR TITLE
Zerovian/pct 369

### DIFF
--- a/src/java/com/phenix/pct/PCTConnection.java
+++ b/src/java/com/phenix/pct/PCTConnection.java
@@ -204,6 +204,37 @@ public class PCTConnection extends DataType {
             throw new BuildException(MessageFormat.format(
                     Messages.getString("PCTConnection.0"), alias.getName())); //$NON-NLS-1$
     }
+    
+    /**
+     * Adds an alias to the current DB connection.
+     * 
+     * This is here to avoid instantiating PCTAlias
+     * 
+     * @param name Alias name
+     */
+    public void addConfiguredPCTAlias(String name) {
+        addConfiguredPCTAlias(name, false);
+    }    
+    
+    /**
+     * Adds an alias to the current DB connection.
+     * 
+     * This is here to avoid instantiating PCTAlias
+     * 
+     * @param name Alias name
+     * @param noError If alias should be declared with NO-ERROR
+     */
+    public void addConfiguredPCTAlias(String name, boolean noError) {
+        
+        if (name == null || name.isEmpty()) {
+            throw new BuildException(Messages.getString("PCTConnection.2"));
+        }
+        
+        PCTAlias alias = new PCTAlias();
+        alias.setName(name);
+        alias.setNoError(noError);
+        addConfiguredPCTAlias(alias);
+    }
 
     protected PCTConnection getRef() {
         return (PCTConnection) getCheckedRef();

--- a/src/java/com/phenix/pct/messages.properties
+++ b/src/java/com/phenix/pct/messages.properties
@@ -40,6 +40,7 @@ PCTCompile.91=Ignoring ProgPerc because of a not supported value: {0}
 
 PCTConnection.0=Alias {0} already defined
 PCTConnection.1=Database name or parameter file not defined
+PCTConnection.2=Mandatory argument: alias name
 
 PCTCRC.0=Mandatory argument : destination file
 PCTCRC.1=No database connection defined

--- a/src/java/com/phenix/pct/messages_fr.properties
+++ b/src/java/com/phenix/pct/messages_fr.properties
@@ -1,126 +1,127 @@
 # $Id$
 
-PCT.1=Attribut {0} : {1} non trouvé
-PCT.2=Progress version {0} détecté
-PCT.3=Variable DLC manquante. L'attribut dlcHome a-t''il été défini ?
-PCT.4=Attribut dlcHome non défini. Utilisation de la propriété DLC : {0}
-PCT.5=Attribut dlcHome non défini. Utilisation de la variable d''environnement DLC : {0}
+PCT.1=Attribut {0} : {1} non trouvÃ©
+PCT.2=Progress version {0} dÃ©tectÃ©
+PCT.3=Variable DLC manquante. L'attribut dlcHome a-t''il Ã©tÃ© dÃ©fini ?
+PCT.4=Attribut dlcHome non dÃ©fini. Utilisation de la propriÃ©tÃ© DLC : {0}
+PCT.5=Attribut dlcHome non dÃ©fini. Utilisation de la variable d''environnement DLC : {0}
 
-PCTBgRun.0=L'attribut {0} ne peut pas être utilisé dans la tâche PCTBgRun
+PCTBgRun.0=L'attribut {0} ne peut pas Ãªtre utilisÃ© dans la tÃ¢che PCTBgRun
 PCTBgRun.1=Pas de gestionnaire pour la commande {0}
-PCTBgRun.2=Le gestionnaire {0} a renvoyé {1} : {2}
+PCTBgRun.2=Le gestionnaire {0} a renvoyÃ© {1} : {2}
 PCTBgRun.3={1} s'est produit : {2} 
 PCTBgRun.4=Erreur durant la suppression des fichiers temporaires
 
-PCTBinaryDump.0=Argument obligatoire : répertoire cible
+PCTBinaryDump.0=Argument obligatoire : rÃ©pertoire cible
 PCTBinaryDump.1=Impossible de lire le fichier temporaire
-PCTBinaryDump.2=Impossible de créer le fichier temporaire
+PCTBinaryDump.2=Impossible de crÃ©er le fichier temporaire
 PCTBinaryDump.3=Impossible de supprimer {0}
 
-PCTBinaryLoad.0=Le timeout doit être supérieur à zéro
-PCTBinaryLoad.1=Aucune connexion à une base de données n'a été définie
-PCTBinaryLoad.2=Plus de {0} connexions sont définies
+PCTBinaryLoad.0=Le timeout doit Ãªtre supÃ©rieur Ã  zÃ©ro
+PCTBinaryLoad.1=Aucune connexion Ã  une base de donnÃ©es n'a Ã©tÃ© dÃ©finie
+PCTBinaryLoad.2=Plus de {0} connexions sont dÃ©finies
 
-PCTCompile.0=Impossible de créer les fichiers temporaires
-PCTCompile.1=noXref n'est plus utilisé et sera supprimé dans les versions futures. Utilisez l'attribut forceCompile
-PCTCompile.2=Impossible d'écrire le fichier contenant la liste des fichiers à compiler
-PCTCompile.3=Impossible d'écrire le fichier contenant les paramètres
-PCTCompile.34=Attribut destDir non défini
-PCTCompile.36=Impossible de créer {0}
+PCTCompile.0=Impossible de crÃ©er les fichiers temporaires
+PCTCompile.1=noXref n'est plus utilisÃ© et sera supprimÃ© dans les versions futures. Utilisez l'attribut forceCompile
+PCTCompile.2=Impossible d'Ã©crire le fichier contenant la liste des fichiers Ã  compiler
+PCTCompile.3=Impossible d'Ã©crire le fichier contenant les paramÃ¨tres
+PCTCompile.34=Attribut destDir non dÃ©fini
+PCTCompile.36=Impossible de crÃ©er {0}
 PCTCompile.40=PCTCompile - Progress Code Compiler
 PCTCompile.42=Impossible de supprimer {0}
-PCTCompile.43=Les attributs xcode et listing sont mutuellement exclusifs. Remise à FAUX de l'attribut listing.
-PCTCompile.44={0} fichier(s) compilé(s)
+PCTCompile.43=Les attributs xcode et listing sont mutuellement exclusifs. Remise Ã  FAUX de l'attribut listing.
+PCTCompile.44={0} fichier(s) compilÃ©(s)
 PCTCompile.45=Erreur de compilation sur {0} fichier(s)
-PCTCompile.46=cpstream est défini à {0}, mais Java ne connait pas cet encodage. Vous pouvez avoir des problèmes si les noms de fichiers contiennent des caractères en dehors de l'ASCII. 
-PCTCompile.47=cpstream n'est pas défini. Vous pouvez avoir des problèmes si les noms de fichiers contiennent des caractères en dehors de l'ASCII. Vous devriez vraiment définir cet attribut !
-PCTCompile.48=Répertoire du fileset {0} non trouvé dans le PROPATH
-PCTCompile.90=Attribut appendStringXref ignoré (stringXref désactivé)
+PCTCompile.46=cpstream est dÃ©fini Ã  {0}, mais Java ne connait pas cet encodage. Vous pouvez avoir des problÃ¨mes si les noms de fichiers contiennent des caractÃ¨res en dehors de l'ASCII. 
+PCTCompile.47=cpstream n'est pas dÃ©fini. Vous pouvez avoir des problÃ¨mes si les noms de fichiers contiennent des caractÃ¨res en dehors de l'ASCII. Vous devriez vraiment dÃ©finir cet attribut !
+PCTCompile.48=RÃ©pertoire du fileset {0} non trouvÃ© dans le PROPATH
+PCTCompile.90=Attribut appendStringXref ignorÃ© (stringXref dÃ©sactivÃ©)
 PCTCompile.91=Invalid value for progPerc : {0}
 
-PCTConnection.0=L'alias {0} est déjà défini
-PCTConnection.1=Le nom de la base ou du fichier de paramètre n'est pas défini
+PCTConnection.0=L'alias {0} est dÃ©jÃ  dÃ©fini
+PCTConnection.1=Le nom de la base ou du fichier de paramÃ¨tre n'est pas dÃ©fini
+PCTConnection.2=Argument obligatoire: nom d'alias
 
 PCTCRC.0=Argument obligatoire : fichier cible
-PCTCRC.1=Aucune connexion à une base de données n'a été définie
+PCTCRC.1=Aucune connexion Ã  une base de donnÃ©es n'a Ã©tÃ© dÃ©finie
 
-PCTCreateBase.0=noSchema n'est plus utilisé et sera supprimé dans les versions futures. Utilisez l'attribut structFile
-PCTCreateBase.2=noInit et noStruct ne peuvent être définis ensemble
-PCTCreateBase.3=Le nom de la base n'est pas défini
-PCTCreateBase.4=Le nom de la base dépasse 11 caractères
-PCTCreateBase.5=Impossible de lire le fichier {0} : impossible de charger le schéma
-PCTCreateBase.6=Fichier de structure {0} non trouvé
+PCTCreateBase.0=noSchema n'est plus utilisÃ© et sera supprimÃ© dans les versions futures. Utilisez l'attribut structFile
+PCTCreateBase.2=noInit et noStruct ne peuvent Ãªtre dÃ©finis ensemble
+PCTCreateBase.3=Le nom de la base n'est pas dÃ©fini
+PCTCreateBase.4=Le nom de la base dÃ©passe 11 caractÃ¨res
+PCTCreateBase.5=Impossible de lire le fichier {0} : impossible de charger le schÃ©ma
+PCTCreateBase.6=Fichier de structure {0} non trouvÃ©
 PCTCreateBase.7=noInit et sourceDb sont mutuellement exclusifs
 PCTCreateBase.8=codepage et sourceDb sont mutuellement exclusifs
-PCTCreateBase.90=Fichier DF de collation {0} non trouvé
+PCTCreateBase.90=Fichier DF de collation {0} non trouvÃ©
 
-PCTDumpData.0=Aucune connexion à une base de données n'a été définie
-PCTDumpData.1=Pas plus d'une connexion dans cette tâche
+PCTDumpData.0=Aucune connexion Ã  une base de donnÃ©es n'a Ã©tÃ© dÃ©finie
+PCTDumpData.1=Pas plus d'une connexion dans cette tÃ¢che
 PCTDumpData.2=Argument obligatoire : fichier de dump
 
-PCTDumpIncremental.0=Aucune connexion à une base de données n'a été définie
-PCTDumpIncremental.1=Deux connexions doivent être définies
-PCTDumpIncremental.3=La base de données maître doit posséder l'alias DICTDB
-PCTDumpIncremental.5=La base de données esclave doit posséder l'alias DICTDB2
+PCTDumpIncremental.0=Aucune connexion Ã  une base de donnÃ©es n'a Ã©tÃ© dÃ©finie
+PCTDumpIncremental.1=Deux connexions doivent Ãªtre dÃ©finies
+PCTDumpIncremental.3=La base de donnÃ©es maÃ®tre doit possÃ©der l'alias DICTDB
+PCTDumpIncremental.5=La base de donnÃ©es esclave doit possÃ©der l'alias DICTDB2
 PCTDumpIncremental.6=Argument obligatoire : fichier de dump
 
-PCTDumpSchema.0=Aucune connexion à une base de données n'a été définie
-PCTDumpSchema.1=Pas plus d'une connexion dans cette tâche
+PCTDumpSchema.0=Aucune connexion Ã  une base de donnÃ©es n'a Ã©tÃ© dÃ©finie
+PCTDumpSchema.1=Pas plus d'une connexion dans cette tÃ¢che
 PCTDumpSchema.2=Argument obligatoire : fichier de dump
 
-PCTLibrary.0=Impossible de créer les fichiers temporaires
-PCTLibrary.1=Le nom de la bibliothèque n'a pas été défini
-PCTLibrary.2=Il faut soit définir l'attribut basedir, soit utiliser au moins un fileset !
-PCTLibrary.3=Un fichier .pl ne peut pas se contenir lui-même !
-PCTLibrary.4=Impossible d'écrire le fichier contenant la liste des fichiers à ajouter à la bibliothèque
+PCTLibrary.0=Impossible de crÃ©er les fichiers temporaires
+PCTLibrary.1=Le nom de la bibliothÃ¨que n'a pas Ã©tÃ© dÃ©fini
+PCTLibrary.2=Il faut soit dÃ©finir l'attribut basedir, soit utiliser au moins un fileset !
+PCTLibrary.3=Un fichier .pl ne peut pas se contenir lui-mÃªme !
+PCTLibrary.4=Impossible d'Ã©crire le fichier contenant la liste des fichiers Ã  ajouter Ã  la bibliothÃ¨que
 PCTLibrary.5=Impossible de supprimer {0}
-PCTLibrary.6=Création de la PL {0}
+PCTLibrary.6=CrÃ©ation de la PL {0}
 PCTLibrary.7=Compression de PL {0}
-PCTLibrary.8=Création memory-mapped PL : {0}
+PCTLibrary.8=CrÃ©ation memory-mapped PL : {0}
 
-PCTLoadData.0=Aucune connexion à une base de données n''a été définie
-PCTLoadData.1=Pas plus d'une connexion dans cette tâche
-PCTLoadData.2=Argument obligatoire : répertoire source
-PCTLoadData.3=Table {0} déjà définie
+PCTLoadData.0=Aucune connexion Ã  une base de donnÃ©es n''a Ã©tÃ© dÃ©finie
+PCTLoadData.1=Pas plus d'une connexion dans cette tÃ¢che
+PCTLoadData.2=Argument obligatoire : rÃ©pertoire source
+PCTLoadData.3=Table {0} dÃ©jÃ  dÃ©finie
 PCTLoadData.4=Utilisez soit l'attribut srcDir ou srcFile
-PCTLoadData.5=Attribut ''table'' non défini
+PCTLoadData.5=Attribut ''table'' non dÃ©fini
 PCTLoadData.6=srcFile n''est pas un fichier
-PCTLoadData.7=srcDir n''est pas un répertoire
+PCTLoadData.7=srcDir n''est pas un rÃ©pertoire
 
-PCTLoadSchema.0=Aucune connexion à une base de données n'a été définie
-PCTLoadSchema.1=Pas plus d'une connexion dans cette tâche
+PCTLoadSchema.0=Aucune connexion Ã  une base de donnÃ©es n'a Ã©tÃ© dÃ©finie
+PCTLoadSchema.1=Pas plus d'une connexion dans cette tÃ¢che
 PCTLoadSchema.2=Argument obligatoire : srcFile ou fileset
-PCTLoadSchema.3=Chargement du fichier {0} dans la base de données
+PCTLoadSchema.3=Chargement du fichier {0} dans la base de donnÃ©es
 PCTLoadSchema.4=Impossible de trouver le fichier {0}
-PCTLoadSchema.5=Impossible de définir à la fois srcFile et un fileset
+PCTLoadSchema.5=Impossible de dÃ©finir Ã  la fois srcFile et un fileset
 
-PCTProxygen.0=Le répertoire de travail n'existe pas
-PCTProxygen.1=Le fichier proxygen n'a pas été défini
-# PCTProxygen.2=Le répertoire d'installation de Progress n'a pas été défini
-PCTProxygen.3=Génération des proxies depuis {0}
+PCTProxygen.0=Le rÃ©pertoire de travail n'existe pas
+PCTProxygen.1=Le fichier proxygen n'a pas Ã©tÃ© dÃ©fini
+# PCTProxygen.2=Le rÃ©pertoire d'installation de Progress n'a pas Ã©tÃ© dÃ©fini
+PCTProxygen.3=GÃ©nÃ©ration des proxies depuis {0}
 
-PCTRun.0=Impossible de créer les fichiers temporaires
+PCTRun.0=Impossible de crÃ©er les fichiers temporaires
 PCTRun.1=Echec : Pas de fichier de sortie
 PCTRun.2=Echec lors de la lecture de la valeur de retour
-PCTRun.3=Echec : Pas de valeur de retour\nSoit votre procédure ne s'est pas terminée correctement, soit votre procédure n'a pas renvoyé de valeur.\nRETURN '0' est nécessaire pour indiquer que la procédure s'est déroulée correctement.
+PCTRun.3=Echec : Pas de valeur de retour\nSoit votre procÃ©dure ne s'est pas terminÃ©e correctement, soit votre procÃ©dure n'a pas renvoyÃ© de valeur.\nRETURN '0' est nÃ©cessaire pour indiquer que la procÃ©dure s'est dÃ©roulÃ©e correctement.
 PCTRun.4=Valeur {0} invalide
 PCTRun.5=Impossible de supprimer {0}
 PCTRun.6=Code retour {0}
-PCTRun.7={0} n'est pas un répertoire
-PCTRun.8=PCTRunOption nécessite un attribute 'name'
-PCTRun.9=Paramètre invalide non pris en compte : {0}
-PCTRun.10=Impossible de définir la propriété {0} avec le contenu du paramètre de sortie (fichier temporaire {1})
+PCTRun.7={0} n'est pas un rÃ©pertoire
+PCTRun.8=PCTRunOption nÃ©cessite un attribute 'name'
+PCTRun.9=ParamÃ¨tre invalide non pris en compte : {0}
+PCTRun.10=Impossible de dÃ©finir la propriÃ©tÃ© {0} avec le contenu du paramÃ¨tre de sortie (fichier temporaire {1})
 
-PCTSchemaDoc.0=Fichier de sortie non défini
-PCTSchemaDoc.1=Aucune connexion à une base de données n'a été définie
-PCTSchemaDoc.2=Pas plus d'une connexion dans cette tâche
+PCTSchemaDoc.0=Fichier de sortie non dÃ©fini
+PCTSchemaDoc.1=Aucune connexion Ã  une base de donnÃ©es n'a Ã©tÃ© dÃ©finie
+PCTSchemaDoc.2=Pas plus d'une connexion dans cette tÃ¢che
 
-PCTWSComp.4=Impossible de créer les fichiers temporaires
-PCTWSComp.6=Impossible d'écrire le fichier contenant la liste des fichiers à compiler
-PCTWSComp.24=Impossible d'écrire le fichier contenant la liste des fichiers à compiler
-PCTWSComp.25=Attribut destDir non défini
-PCTWSComp.26=destDir n'est pas un répertoire
-PCTWSComp.27=Impossible de créer destDir
+PCTWSComp.4=Impossible de crÃ©er les fichiers temporaires
+PCTWSComp.6=Impossible d'Ã©crire le fichier contenant la liste des fichiers Ã  compiler
+PCTWSComp.24=Impossible d'Ã©crire le fichier contenant la liste des fichiers Ã  compiler
+PCTWSComp.25=Attribut destDir non dÃ©fini
+PCTWSComp.26=destDir n'est pas un rÃ©pertoire
+PCTWSComp.27=Impossible de crÃ©er destDir
 PCTWSComp.28=PCTWSComp - Progress WebSpeed Code Compiler
 PCTWSComp.30=Impossible de supprimer {0}
 
@@ -129,21 +130,21 @@ PCTXCode.3=Unable to create directory : {0}
 PCTXCode.4=destDir not defined
 PCTXCode.5=PCTXCode - Progress Encryption Tool
 PCTXCode.6=Encryption of {0}
-PCTXCode.7=Impossible d'écraser le fichier {0}
+PCTXCode.7=Impossible d'Ã©craser le fichier {0}
 PCTXCode.13=Failed to delete {0}
 
-PLReader.0=L'octet à la position {0} devrait valoir FF ou FE mais vaut {1} 
-PLReader.6=Fichier {0} [{1}] Ajouté le {2,date,dd/MM/yyyy hh:mm:ss} Modifié le {3,date,dd/MM/yyyy hh:mm:ss} [Décalage : {4}]
+PLReader.0=L'octet Ã  la position {0} devrait valoir FF ou FE mais vaut {1} 
+PLReader.6=Fichier {0} [{1}] AjoutÃ© le {2,date,dd/MM/yyyy hh:mm:ss} ModifiÃ© le {3,date,dd/MM/yyyy hh:mm:ss} [DÃ©calage : {4}]
 PLReader.12=Format de fichier incorrect 
 
-ProUnit.0=L'attribut {0} n'est pas défini ou invalide
-ProUnit.1=Cet attribut n'est pas utilisé pour l'instant !!!
+ProUnit.0=L'attribut {0} n'est pas dÃ©fini ou invalide
+ProUnit.1=Cet attribut n'est pas utilisÃ© pour l'instant !!!
 
-PLExtract.1=L'attribut src n'est pas défini ou invalide
-PLExtract.2=L'attribut dest n'est pas défini ou invalide
+PLExtract.1=L'attribut src n'est pas dÃ©fini ou invalide
+PLExtract.2=L'attribut dest n'est pas dÃ©fini ou invalide
 
-OpenEdgeClassDocumentation.0=Attribut {0} non défini
-OpenEdgeClassDocumentation.1=Pas de fileset défini
+OpenEdgeClassDocumentation.0=Attribut {0} non dÃ©fini
+OpenEdgeClassDocumentation.1=Pas de fileset dÃ©fini
 
-OpenEdgeXMLDocumentation.0=Attribut {0} non défini
-OpenEdgeXMLDocumentation.1=Pas de fileset défini
+OpenEdgeXMLDocumentation.0=Attribut {0} non dÃ©fini
+OpenEdgeXMLDocumentation.1=Pas de fileset dÃ©fini

--- a/src/test/com/phenix/pct/PCTConnectionTest.java
+++ b/src/test/com/phenix/pct/PCTConnectionTest.java
@@ -50,6 +50,38 @@ public class PCTConnectionTest extends BuildFileTestNg {
         PCTConnection conn = new PCTConnection();
         conn.createArguments(exec);
     }
+    
+    // should allow alias by name without instantiating pctalias
+    @Test(groups = {"v10"})
+    public void addConfiguredPCTAlias() {
+        PCTConnection conn = new PCTConnection();
+
+        if (conn.getAliases().size() > 0) {
+            fail("No aliases should be defined at this time");
+        }
+        
+        conn.addConfiguredPCTAlias("boston");
+        
+        assertTrue(conn.hasNamedAlias("boston"));
+        
+        conn.addConfiguredPCTAlias("miami", true);
+        
+        assertTrue(conn.hasNamedAlias("miami"));
+        
+    }
+    
+    // should fail because alias name is blank
+    @Test(groups = {"v10"}, expectedExceptions = BuildException.class)
+    public void addConfiguredPCTAliasErrors() {
+        PCTConnection conn = new PCTConnection();
+
+        if (conn.getAliases().size() > 0) {
+            fail("No aliases should be defined at this time");
+        }
+        
+        conn.addConfiguredPCTAlias("");
+        
+    }    
 
     @Test(groups = {"v10"})
     public void testAliases() {


### PR DESCRIPTION
# Description

Adds a new method to PCTConnection for convenience where import of PCTAlias isn't possible within a gradle plugin written in groovy.

Fixes # 369

## Type of change
Adds a new method to PCTConnection

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My branch is started from the latest commit in master
- [X ] My commit history is clean
- [X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [X ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
