### PR TITLE
Class Compile Hierarchy - Doesn't account for parent class include file changes

### DIFF
--- a/src/progress/pct/compile.p
+++ b/src/progress/pct/compile.p
@@ -997,7 +997,7 @@ FUNCTION checkHierarchy RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT ts AS DATET
              TimeStamps.ttFullPath = SEARCH(REPLACE(clsName, '.', '/') + '.cls').
       ASSIGN TimeStamps.ttMod = getTimeStampF(TimeStamps.ttFullPath).
     END.
-    IF ((TimeStamps.ttFullPath NE clsFullPath) OR (ts LT TimeStamps.ttMod)) AND (TimeStamps.ttExcept EQ FALSE) THEN DO:
+    IF ((TimeStamps.ttFullPath NE clsFullPath) OR (ts LT TimeStamps.ttMod) OR CheckIncludes(REPLACE(clsName, '.', '/') + '.cls', ts, d)) AND (TimeStamps.ttExcept EQ FALSE) THEN DO:
       ASSIGN lReturn = TRUE.
       LEAVE FileList.
     END.

--- a/src/test/com/phenix/pct/PCTCompileTest.java
+++ b/src/test/com/phenix/pct/PCTCompileTest.java
@@ -1649,6 +1649,32 @@ public class PCTCompileTest extends BuildFileTestNg {
         assertTrue(f2.exists());
     }
 
+    @Test(groups = {"v11"})
+    public void test89() throws IOException {
+        configureProject(BASEDIR + "test89/build.xml");
+
+        // Compile everything
+        Files.copy(new File(BASEDIR + "test89/src/inc/ttTable1.i"),
+                new File(BASEDIR + "test89/src/inc/ttTable-comp.i"));
+        executeTarget("test");
+
+        // Save the last modified date of our child class
+        File f1 = new File(BASEDIR + "test89/build/cls/someChildClass.r");
+        long lastModTime = f1.lastModified();
+
+        // Do an incremental compile with a new include for the parent class
+        // This would have previously skipped compiling the child class because the child was only
+        // checking if the
+        // parent class had changed and not whether an include referenced by the parent class
+        // changed.
+        // The child class needs to be compiled since it references a table from an include in the
+        // parent class.
+        Files.copy(new File(BASEDIR + "test89/src/inc/ttTable2.i"),
+                new File(BASEDIR + "test89/src/inc/ttTable-comp.i"));
+        executeTarget("test");
+        assertNotEquals(f1.lastModified(), lastModTime);
+    }
+
     static final class Test80LineProcessor implements LineProcessor<Boolean> {
         private boolean rslt = true;
         private int numLines;

--- a/tests/PCTCompile/test89/build.xml
+++ b/tests/PCTCompile/test89/build.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<project name="PCTCompile-test89">
+  <taskdef resource="PCT.properties" />
+
+  <target name="test">
+    <mkdir dir="build" />
+    <PCTCompile destDir="build"
+                failOnError="false"
+                displayFiles="1">
+      <propath location="src" />
+      <fileset dir="src" includes="**/*.cls" />
+    </PCTCompile>
+    <sleep seconds="1" /> <!-- otherwise we're too fast for the unit test -->
+  </target>
+
+</project>

--- a/tests/PCTCompile/test89/src/cls/someChildClass.cls
+++ b/tests/PCTCompile/test89/src/cls/someChildClass.cls
@@ -1,0 +1,9 @@
+class cls.someChildClass inherits cls.someClass:
+
+  method public void createRecordChild () :
+    create ttTable.
+    assign ttTable.someChar = "test".
+    release ttTable.
+  end method.
+
+end class.

--- a/tests/PCTCompile/test89/src/cls/someClass.cls
+++ b/tests/PCTCompile/test89/src/cls/someClass.cls
@@ -1,0 +1,18 @@
+class cls.someClass:
+
+  {inc/ttTable-comp.i}
+
+  method public void createRecord () :
+    create ttTable.
+    assign ttTable.someChar = "some value 1".
+    release ttTable.
+  end method.
+
+  method public void displayRecord () :
+    message 100.
+    for first ttTable no-lock:
+      message 101 ttTable.someChar.
+    end.
+  end method.
+
+end class.

--- a/tests/PCTCompile/test89/src/inc/ttTable1.i
+++ b/tests/PCTCompile/test89/src/inc/ttTable1.i
@@ -1,0 +1,2 @@
+define protected temp-table ttTable no-undo
+  field someChar as character.

--- a/tests/PCTCompile/test89/src/inc/ttTable2.i
+++ b/tests/PCTCompile/test89/src/inc/ttTable2.i
@@ -1,0 +1,3 @@
+define protected temp-table ttTable no-undo
+  field someChar as character
+  field someChar2 as character.


### PR DESCRIPTION
# Description

When compiling incrementally child classes which reference temp-tables defined in an include which was referenced by the parent class, the child class fails to compile.

Fixes #455

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My branch is started from the latest commit in master
- [x] My commit history is clean
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
