### PR TITLE
#503 PctCompile add displayFiles option 3 to display timestamp info

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,9 +68,9 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+<https://www.contributor-covenant.org/faq>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,24 @@
+# Contributing
+
 ## How to report bugs ?
 
 * Please use the Issues page on GitHub.
 * Use the provided templates to report issue
 * Always include the version number of PCT and OpenEdge ; you can easily get this information by including the following statements in your build.xml :
+
 ```xml
  <PCTVersion />
  <ProgressVersion dlcHome="${DLC}" fullVersion="dlc.version.full" />
  <echo message="${dlc.version.full}" />
 ```
+
 Which will give you something like:
-```
+
+```text
 [PCTVersion] PCT Version : jenkins-Dev1-PCT-376
      [echo] OpenEdge Release 11.5 as of Fri Dec  5 19:02:15 EST 2014
 ```
+
 * Upgrade to the latest version of PCT if possible
 * Include a verbose log of your problem, by using `ant -v`
 * For old versions of PCT, include a verbose log by adding verbose="true" in your PCTRun or PCTCompile statement
@@ -24,6 +30,7 @@ Which will give you something like:
 
 * JDK 11 is required
 * Modify `pct.build.properties` to match your OpenEdge installation dir
+  * if you don't want to modify the properties you can create a symbolic link using `mklink /j /d C:\\Progress\\OpenEdge-12.6 your-oe126-path` in an administrator command prompt
 * Make sure you don’t have PCT.jar in `$ANT_HOME/lib`
 * Execute `ant clean jar` (or `ant clean classDoc jar` if you want to test ClassDocumentation on Windows) to build everything (PCT.jar is created in dist/ directory)
 * Execute `ant prepare-test` to (re)generate the testbox dir, where tests are executed

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
+# PCT
+
 PCT is a set of [Ant](http://ant.apache.org) tasks for the [OpenEdge](https://www.progress.com/openedge) environment, distributed under the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
 
 This project was born due to the lack of automated OpenEdge build environment. PCT is a command-line based tool, so you can use it in with any continuous integration and delivery product.
 
-PCT has been designed and written by Gilles QUERRET ([Riverside Software](http://riverside-software.fr)). 
+PCT has been designed and written by Gilles QUERRET ([Riverside Software](http://riverside-software.fr)).
 
-### Documentation ###
+## Documentation
 
 Documentation is available [in the Wiki pages](https://wiki.rssw.eu/pct/)
 
-### What's next
+## What's next
 
 * Need to assess the quality of your source code ? Find bugs, vulnerabilities and code smells ? Then try [CABL](https://riverside-software.fr/progress-openedge-abl-features-for-cleaner-and-safer-code) for [SonarQube](http://www.sonarqube.org).
 * Working with [OpenEdge WebClient](https://www.progress.com/support/openedge/webclient-executables)? Then you may want to use [PDO](https://pdo.riverside-software.fr) to build and distribute applications in a completely automated way.
 
-### Status
+## Status
 
 ![Build Status](https://ci.rssw.eu/job/PCT/job/main/badge/icon)
 

--- a/src/progress/pct/compile.p
+++ b/src/progress/pct/compile.p
@@ -135,10 +135,12 @@ DEFINE VARIABLE iStepPerc AS INTEGER    NO-UNDO.
 DEFINE VARIABLE cDspSteps AS CHARACTER  NO-UNDO.
 DEFINE VARIABLE cIgnoredIncludes AS CHARACTER  NO-UNDO.
 DEFINE VARIABLE lIgnoredIncludes AS LOGICAL    NO-UNDO.
-DEFINE VARIABLE iFileList AS INTEGER    NO-UNDO.
+DEFINE VARIABLE iFileList AS INTEGER    NO-UNDO. /* DisplayFiles value */
 DEFINE VARIABLE callbackClass AS CHARACTER NO-UNDO.
 DEFINE VARIABLE outputType AS CHARACTER NO-UNDO.
-DEFINE VARIABLE cLastIncludeName AS CHARACTER NO-UNDO.
+DEFINE VARIABLE cLastReferenceName AS CHARACTER NO-UNDO.
+DEFINE VARIABLE cLastPath AS CHARACTER NO-UNDO.
+DEFINE VARIABLE cLastTS AS DATETIME NO-UNDO.
 
 DEFINE VARIABLE lOutputJson    AS LOGICAL NO-UNDO INITIAL FALSE.
 DEFINE VARIABLE lOutputConsole AS LOGICAL NO-UNDO INITIAL FALSE.
@@ -174,7 +176,7 @@ PROCEDURE setOption:
   DEFINE INPUT PARAMETER ipValue AS CHARACTER NO-UNDO.
 
   CASE ipName:
-    when 'OUTPUTDIR':U        THEN ASSIGN DestDir = ipValue.
+    WHEN 'OUTPUTDIR':U        THEN ASSIGN DestDir = ipValue.
     WHEN 'PCTDIR':U           THEN ASSIGN PCTDir = ipValue.
     WHEN 'FORCECOMPILE':U     THEN ASSIGN ForceComp = (ipValue EQ '1':U).
     WHEN 'XCODE':U            THEN ASSIGN lXCode = (ipValue EQ '1':U).
@@ -243,7 +245,7 @@ PROCEDURE initModule:
     RETURN RETURN-VALUE.
 
   /* Checks if valid config */
-  OutputDir = if DestDir ne ? then DestDir else ".".
+  OutputDir = IF DestDir NE ? THEN DestDir ELSE ".".
   IF NOT FileExists(OutputDir) THEN
     RETURN '4'.
   IF NOT FileExists(PCTDir) THEN
@@ -319,6 +321,7 @@ PROCEDURE compileXref:
   DEFINE VARIABLE cRenameFrom AS CHARACTER NO-UNDO INITIAL ''.
   DEFINE VARIABLE lWarnings AS LOGICAL NO-UNDO INITIAL FALSE.
   DEFINE VARIABLE lOneWarning AS LOGICAL NO-UNDO INITIAL FALSE.
+  DEFINE VARIABLE cRcodeFullPath AS CHARACTER NO-UNDO.
 
   EMPTY TEMP-TABLE ttWarnings. /* Emptying the temp-table to store warnings for current file*/
   /* Output progress */
@@ -365,7 +368,7 @@ PROCEDURE compileXref:
     IF (opError) THEN RETURN.
     ASSIGN opError = NOT createDir(PCTDir, cBase2).
     IF (opError) THEN RETURN.
-    ASSIGN cRenameFrom = cBase + (IF cbase EQ '' THEN '' ELSE '/') + substring(cfile, 1, R-INDEX(cfile, '.') - 1) + '.r'.
+    ASSIGN cRenameFrom = cBase + (IF cbase EQ '' THEN '' ELSE '/') + SUBSTRING(cfile, 1, R-INDEX(cfile, '.') - 1) + '.r'.
   END.
 
   IF (noParse OR ForceComp OR lXCode) THEN DO:
@@ -374,27 +377,30 @@ PROCEDURE compileXref:
   ELSE DO:
     /* Does .r file exists ?,
        if DestDir = unknown rcode will be located in the same directory as the source : ipInDir */
-    ASSIGN RCodeTS = getTimeStampDF(if DestDir = ? then ipInDir else OutputDir, ipOutFile).
+    ASSIGN RCodeTS = getTimeStampDF(IF DestDir = ? THEN ipInDir ELSE OutputDir, ipOutFile).
     IF (RCodeTS EQ ?) THEN DO:
-      opComp = 1.
+      opComp = 1. /* No rcode */
     END.
     ELSE DO:
+      cRcodeFullPath = FILE-INFO:FULL-PATHNAME. /* relying on side-effect of getTimeStampDF */
       /* Checking if .r timestamp is prior to procedure timestamp */
       ASSIGN ProcTS = getTimeStampDF(ipInDir, ipInFile).
       IF (ProcTS GT RCodeTS) THEN DO:
-        opComp = 2.
+        cLastPath = SUBSTITUTE("source:&1", FILE-INFO:FULL-PATHNAME). /* relying on side-effect of getTimeStampDF */
+        cLastTS = ProcTS.
+        opComp = 2. /* 'R-code older than source'. */
       END.
       ELSE DO:
         IF CheckIncludes(ipInFile, RCodeTS, PCTDir) THEN DO:
-          opComp = 3.
+          opComp = 3. /* R-code older than include file */
         END.
         ELSE DO:
           IF CheckCRC(ipInFile, PCTDir) THEN DO:
-            opComp = 4.
+            opComp = 4. /* Table CRC */
           END.
           ELSE DO:
             IF CheckHierarchy(ipInFile, RCodeTS, PCTDir) THEN DO:
-              opComp = 6.
+              opComp = 6. /* Hierarchy change */
             END.
           END.
         END.
@@ -402,8 +408,13 @@ PROCEDURE compileXref:
     END.
   END.
   IF (iFileList GT 0) THEN DO:
-    IF ((iFileList EQ 1) AND (opComp GT 0) ) OR (iFileList EQ 2) THEN DO:
-      RUN logInfo IN hSrcProc (SUBSTITUTE("&1 [&2&3]", ipInFile, getRecompileLabel(opComp), IF opComp = 3 THEN ": " + cLastIncludeName ELSE "")).
+    IF ((iFileList EQ 1 OR iFileList EQ 3) AND (opComp GT 0) ) OR (iFileList EQ 2) THEN DO:
+      RUN logInfo IN hSrcProc (SUBSTITUTE("&1 [&2&3]", ipInFile, getRecompileLabel(opComp), IF (opComp EQ 3 OR opComp EQ 6) THEN ": " + cLastReferenceName ELSE "")).
+      IF iFileList EQ 3 AND (opComp EQ 2 OR opComp EQ 3 OR opComp EQ 6)
+      THEN DO:
+        RUN logInfo IN hSrcProc (SUBSTITUTE("&1 : rcode &2", ISO-DATE(RCodeTS), cRcodeFullPath)).
+        RUN logInfo IN hSrcProc (SUBSTITUTE("&1 : &2", ISO-DATE(cLastTS), cLastPath)).
+      END.
     END.
   END.
   IF opComp EQ 0 THEN RETURN.
@@ -518,9 +529,9 @@ PROCEDURE compileXref:
           CREATE ttProjectWarnings.
           ASSIGN ttProjectWarnings.msgNum       = ttWarnings.msgNum
                  ttProjectWarnings.rowNum       = ttWarnings.rowNum
-                 ttProjectWarnings.fileName     = REPLACE(ttWarnings.fileName, chr(92), '/')
+                 ttProjectWarnings.fileName     = REPLACE(ttWarnings.fileName, CHR(92), '/')
                  ttProjectWarnings.msg          = ttWarnings.msg
-                 ttProjectWarnings.mainFileName = REPLACE(ipInDir + (if ipInDir eq '':U then '':U else '/':U) + ipInFile, chr(92), '/').
+                 ttProjectWarnings.mainFileName = REPLACE(ipInDir + (IF ipInDir EQ '':U THEN '':U ELSE '/':U) + ipInFile, CHR(92), '/').
         END.
       END.
       IF lOutputConsole THEN DO:
@@ -557,8 +568,8 @@ PROCEDURE compileXref:
     IF lOutputJson THEN DO:
       FOR EACH ttErrors:
         CREATE ttProjectErrors.
-        ASSIGN ttProjectErrors.fileName      = REPLACE(ttErrors.fileName, chr(92), '/')
-               ttProjectErrors.mainFileName  = REPLACE(ipInDir + (if ipInDir eq '':U then '':U else '/':U) + ipInFile, chr(92), '/')
+        ASSIGN ttProjectErrors.fileName      = REPLACE(ttErrors.fileName, CHR(92), '/')
+               ttProjectErrors.mainFileName  = REPLACE(ipInDir + (IF ipInDir EQ '':U THEN '':U ELSE '/':U) + ipInFile, CHR(92), '/')
                ttProjectErrors.rowNum        = ttErrors.rowNum
                ttProjectErrors.colNum        = ttErrors.colNum
                ttProjectErrors.msg           = ttErrors.msg.
@@ -781,6 +792,8 @@ PROCEDURE importXref PRIVATE:
   EMPTY TEMP-TABLE ttXrefCRC.
   EMPTY TEMP-TABLE ttXrefClasses.
 
+  DEFINE BUFFER lbTimeStamps FOR TimeStamps.
+
   INPUT STREAM sXREF FROM VALUE (pcXref).
   INPUT STREAM sXREF2 FROM VALUE (pcXref).
   REPEAT:
@@ -890,17 +903,17 @@ PROCEDURE importXref PRIVATE:
     OUTPUT TO VALUE (pcDir + '/':U + pcFile + '.run':U).
     FOR EACH ttXref WHERE ttXref.xRefType EQ 'RUN':U AND ((ttXref.xObjID MATCHES '*~~.p') OR (ttXref.xObjID MATCHES '*~~.w')) NO-LOCK BREAK BY ttXref.xObjID:
       IF FIRST-OF (ttXref.xObjID) THEN DO:
-        FIND TimeStamps WHERE TimeStamps.ttFile EQ ttXref.xObjID NO-LOCK NO-ERROR.
-        IF (NOT AVAILABLE TimeStamps) THEN DO:
+        FIND lbTimeStamps WHERE lbTimeStamps.ttFile EQ ttXref.xObjID NO-LOCK NO-ERROR.
+        IF (NOT AVAILABLE lbTimeStamps) THEN DO:
           ASSIGN cSearch = SEARCH(SUBSTRING(ttXref.xObjID, 1, R-INDEX(ttXref.xObjID, '.')) + 'r').
           IF (cSearch EQ ?) THEN
             ASSIGN cSearch = SEARCH(ttXref.xObjID).
-          CREATE TimeStamps.
-          ASSIGN TimeStamps.ttFile = ttXref.xObjID
-                 TimeStamps.ttFullPath = (IF cSearch EQ ? THEN 'NOT FOUND' ELSE cSearch).
-          ASSIGN TimeStamps.ttMod = getTimeStampF(TimeStamps.ttFullPath).
+          CREATE lbTimeStamps.
+          ASSIGN lbTimeStamps.ttFile = ttXref.xObjID
+                 lbTimeStamps.ttFullPath = (IF cSearch EQ ? THEN 'NOT FOUND' ELSE cSearch).
+          ASSIGN lbTimeStamps.ttMod = getTimeStampF(lbTimeStamps.ttFullPath).
         END.
-        EXPORT ttXref.xObjID TimeStamps.ttFullPath.
+        EXPORT ttXref.xObjID lbTimeStamps.ttFullPath.
       END.
     END.
     OUTPUT CLOSE.
@@ -921,6 +934,7 @@ FUNCTION CheckIncludes RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT ts AS DATETI
   DEFINE VARIABLE IncFile     AS CHARACTER  NO-UNDO.
   DEFINE VARIABLE IncFullPath AS CHARACTER  NO-UNDO.
   DEFINE VARIABLE lReturn     AS LOGICAL    NO-UNDO INITIAL FALSE.
+DEFINE BUFFER lbTimeStamps FOR TimeStamps.
 
   /* Small workaround when compiling classes */
   FILE-INFO:FILE-NAME = d + '/':U + f + '.inc':U.
@@ -932,20 +946,24 @@ FUNCTION CheckIncludes RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT ts AS DATETI
   FileList:
   REPEAT:
     IMPORT STREAM sIncludes IncFile IncFullPath.
-    FIND TimeStamps WHERE TimeStamps.ttFile EQ IncFile NO-LOCK NO-ERROR.
-    IF (NOT AVAILABLE TimeStamps) THEN DO:
-      CREATE TimeStamps.
-      ASSIGN TimeStamps.ttFile = IncFile
-             TimeStamps.ttFullPath = SEARCH(IncFile).
-      ASSIGN TimeStamps.ttMod = getTimeStampF(TimeStamps.ttFullPath).
+    FIND lbTimeStamps WHERE lbTimeStamps.ttFile EQ IncFile NO-LOCK NO-ERROR.
+    IF (NOT AVAILABLE lbTimeStamps) THEN DO:
+      CREATE lbTimeStamps.
+      ASSIGN lbTimeStamps.ttFile = IncFile
+             lbTimeStamps.ttFullPath = SEARCH(IncFile).
+      ASSIGN lbTimeStamps.ttMod = getTimeStampF(lbTimeStamps.ttFullPath).
       IF lIgnoredIncludes AND CAN-DO(cIgnoredIncludes, REPLACE(IncFile, '~\':U, '/':U)) THEN /* include is not relevant for recompile */ DO:
         RUN logVerbose IN hSrcProc (SUBSTITUTE('Ignoring changes in &1', IncFile)).
-        ASSIGN TimeStamps.ttExcept = TRUE.
+        ASSIGN lbTimeStamps.ttExcept = TRUE.
       END.
     END.
-    IF ((TimeStamps.ttFullPath NE IncFullPath) OR (TS LT TimeStamps.ttMod)) AND (TimeStamps.ttExcept EQ FALSE) THEN DO:
+    IF ((lbTimeStamps.ttFullPath NE IncFullPath) OR (TS LT lbTimeStamps.ttMod)) AND (lbTimeStamps.ttExcept EQ FALSE) THEN DO:
       ASSIGN lReturn = TRUE
-             cLastIncludeName = IncFile.
+             cLastReferenceName = IncFile
+             cLastTS = lbTimeStamps.ttMod.
+      IF (lbTimeStamps.ttFullPath NE IncFullPath)
+      THEN cLastPath = SUBSTITUTE("include:&1 timestamp:&2", IncFullPath, lbTimeStamps.ttFullPath).
+      ELSE cLastPath = SUBSTITUTE("include:&1", lbTimeStamps.ttFullPath).
       LEAVE FileList.
     END.
   END.
@@ -984,7 +1002,7 @@ FUNCTION checkHierarchy RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT ts AS DATET
   DEFINE VARIABLE clsName     AS CHARACTER  NO-UNDO.
   DEFINE VARIABLE clsFullPath AS CHARACTER  NO-UNDO.
   DEFINE VARIABLE lReturn     AS LOGICAL    NO-UNDO INITIAL FALSE.
-
+  DEFINE BUFFER lbTimeStamps FOR TimeStamps.
   /* Small workaround when compiling classes */
   FILE-INFO:FILE-NAME = d + '/':U + f + '.hierarchy':U.
   IF FILE-INFO:FULL-PATHNAME EQ ? THEN DO:
@@ -995,15 +1013,22 @@ FUNCTION checkHierarchy RETURNS LOGICAL (INPUT f AS CHARACTER, INPUT ts AS DATET
   FileList:
   REPEAT:
     IMPORT STREAM sHierarchy clsName clsFullPath.
-    FIND TimeStamps WHERE TimeStamps.ttFile EQ clsName NO-LOCK NO-ERROR.
-    IF (NOT AVAILABLE TimeStamps) THEN DO:
-      CREATE TimeStamps.
-      ASSIGN TimeStamps.ttFile = clsName
-             TimeStamps.ttFullPath = SEARCH(REPLACE(clsName, '.', '/') + '.cls').
-      ASSIGN TimeStamps.ttMod = getTimeStampF(TimeStamps.ttFullPath).
+    FIND lbTimeStamps WHERE lbTimeStamps.ttFile EQ clsName NO-LOCK NO-ERROR.
+    IF (NOT AVAILABLE lbTimeStamps) THEN DO:
+      CREATE lbTimeStamps.
+      ASSIGN lbTimeStamps.ttFile = clsName
+             lbTimeStamps.ttFullPath = SEARCH(REPLACE(clsName, '.', '/') + '.cls').
+      ASSIGN lbTimeStamps.ttMod = getTimeStampF(lbTimeStamps.ttFullPath).
     END.
-    IF ((TimeStamps.ttFullPath NE clsFullPath) OR (ts LT TimeStamps.ttMod) OR CheckIncludes(REPLACE(clsName, '.', '/') + '.cls', ts, d)) AND (TimeStamps.ttExcept EQ FALSE) THEN DO:
-      ASSIGN lReturn = TRUE.
+    IF ((lbTimeStamps.ttFullPath NE clsFullPath) OR (ts LT lbTimeStamps.ttMod) OR CheckIncludes(REPLACE(clsName, '.', '/') + '.cls', ts, d)) AND (lbTimeStamps.ttExcept EQ FALSE) THEN DO:
+      ASSIGN lReturn = TRUE
+             cLastReferenceName = clsName
+             cLastTS = lbTimeStamps.ttMod.
+      IF (lbTimeStamps.ttFullPath NE clsFullPath)
+      THEN cLastPath = SUBSTITUTE("cls:&1 timestamp:&2", clsFullPath, lbTimeStamps.ttFullPath).
+      ELSE cLastPath = SUBSTITUTE("cls:&1", lbTimeStamps.ttFullPath).
+      LEAVE FileList.
+
       LEAVE FileList.
     END.
   END.

--- a/src/test/com/phenix/pct/PCTCompileExtTest.java
+++ b/src/test/com/phenix/pct/PCTCompileExtTest.java
@@ -1435,6 +1435,38 @@ public class PCTCompileExtTest extends BuildFileTestNg {
     }
 
     @Test(groups = {"v11"})
+    public void test93() {
+        configureProject(BASEDIR + "test93/build.xml");
+        // First build
+        expectLog("test1", new String[]{"PCTCompile - Progress Code Compiler", "test.p [No r-code]",
+                "test2.p [No r-code]", "2 file(s) compiled"});
+        // Second build, nothing compiled
+        expectLog("test1",
+                new String[]{"PCTCompile - Progress Code Compiler", "0 file(s) compiled"});
+
+        // Touch test.p
+        expectLog("test2", new String[]{"[PCTCompile] PCTCompile - Progress Code Compiler", //
+            "[PCTCompile] test.p [R-code older than source]", //
+            "[PCTCompile] 2023-02-28T09:44:40.000 : rcode test.r", //
+            "[PCTCompile] 2023-02-28T09:44:49.000 : source:test.p", //
+            "[PCTCompile] test2.p [R-code older than source]", //
+            "[PCTCompile] 2023-02-28T09:44:40.000 : rcode test2.r", //
+            "[PCTCompile] 2023-02-28T09:44:49.000 : source:test2.p", //
+            "[PCTCompile] 2 file(s) compiled"
+            });
+        // Touch test.i
+        expectLog("test3", new String[]{"[PCTCompile] PCTCompile - Progress Code Compiler", //
+            "[PCTCompile] test.p [R-code older than include file: test.i]", //
+            "[PCTCompile] 2023-02-28T09:44:49.000 : rcode build\test.r", //
+            "[PCTCompile] 2023-02-28T09:48:47.000 : include:src\test.i", //
+            "[PCTCompile] test2.p [R-code older than include file: test2.i]", //
+            "[PCTCompile] 2023-02-28T09:44:49.000 : rcode build\test2.r", //
+            "[PCTCompile] 2023-02-28T09:48:47.000 : include:src\test2.i", //
+            "[PCTCompile] 2 file(s) compiled"
+            });
+    }
+
+    @Test(groups = {"v11"})
     public void test101() {
         configureProject(BASEDIR + "test101/build.xml");
         executeTarget("test");

--- a/src/test/com/phenix/pct/PCTCompileExtTest.java
+++ b/src/test/com/phenix/pct/PCTCompileExtTest.java
@@ -1438,32 +1438,35 @@ public class PCTCompileExtTest extends BuildFileTestNg {
     public void test93() {
         configureProject(BASEDIR + "test93/build.xml");
         // First build
-        expectLog("test1", new String[]{"PCTCompile - Progress Code Compiler", "test.p [No r-code]",
+        expectLog("test1", new String[]{ //
+                "PCTCompile - Progress Code Compiler", //
+                "test.p [No r-code]", //
                 "test2.p [No r-code]", "2 file(s) compiled"});
         // Second build, nothing compiled
-        expectLog("test1",
-                new String[]{"PCTCompile - Progress Code Compiler", "0 file(s) compiled"});
+        expectLog("test1", new String[]{ //
+                "PCTCompile - Progress Code Compiler", //
+                "0 file(s) compiled"});
 
         // Touch test.p
-        expectLog("test2", new String[]{"[PCTCompile] PCTCompile - Progress Code Compiler", //
-            "[PCTCompile] test.p [R-code older than source]", //
-            "[PCTCompile] 2023-02-28T09:44:40.000 : rcode test.r", //
-            "[PCTCompile] 2023-02-28T09:44:49.000 : source:test.p", //
-            "[PCTCompile] test2.p [R-code older than source]", //
-            "[PCTCompile] 2023-02-28T09:44:40.000 : rcode test2.r", //
-            "[PCTCompile] 2023-02-28T09:44:49.000 : source:test2.p", //
-            "[PCTCompile] 2 file(s) compiled"
-            });
+        expectLog("test2", new String[]{ //
+                "PCTCompile - Progress Code Compiler", //
+                "test.p [R-code older than source]", //
+                "2023-02-28T09:44:40.000 : rcode test.r", //
+                "2023-02-28T09:44:49.000 : source:test.p", //
+                "test2.p [R-code older than source]", //
+                "2023-02-28T09:44:40.000 : rcode test2.r", //
+                "2023-02-28T09:44:49.000 : source:test2.p", //
+                "2 file(s) compiled"});
         // Touch test.i
-        expectLog("test3", new String[]{"[PCTCompile] PCTCompile - Progress Code Compiler", //
-            "[PCTCompile] test.p [R-code older than include file: test.i]", //
-            "[PCTCompile] 2023-02-28T09:44:49.000 : rcode build\test.r", //
-            "[PCTCompile] 2023-02-28T09:48:47.000 : include:src\test.i", //
-            "[PCTCompile] test2.p [R-code older than include file: test2.i]", //
-            "[PCTCompile] 2023-02-28T09:44:49.000 : rcode build\test2.r", //
-            "[PCTCompile] 2023-02-28T09:48:47.000 : include:src\test2.i", //
-            "[PCTCompile] 2 file(s) compiled"
-            });
+        expectLog("test3", new String[]{ //
+                "PCTCompile - Progress Code Compiler", //
+                "test.p [R-code older than include file: test.i]", //
+                "2023-02-28T09:44:49.000 : rcode build\test.r", //
+                "2023-02-28T09:48:47.000 : include:src\test.i", //
+                "test2.p [R-code older than include file: test2.i]", //
+                "2023-02-28T09:44:49.000 : rcode build\test2.r", //
+                "2023-02-28T09:48:47.000 : include:src\test2.i", //
+                "2 file(s) compiled"});
     }
 
     @Test(groups = {"v11"})

--- a/src/test/com/phenix/pct/PCTCompileTest.java
+++ b/src/test/com/phenix/pct/PCTCompileTest.java
@@ -1729,35 +1729,36 @@ public class PCTCompileTest extends BuildFileTestNg {
 
     @Test(groups = {"v11"})
     public void test93() {
-
         configureProject(BASEDIR + "test93/build.xml");
         // First build
-        expectLog("test1", new String[]{"PCTCompile - Progress Code Compiler", "test.p [No r-code]",
+        expectLog("test1", new String[]{ //
+                "PCTCompile - Progress Code Compiler", "test.p [No r-code]", //
                 "test2.p [No r-code]", "2 file(s) compiled"});
         // Second build, nothing compiled
-        expectLog("test1",
-                new String[]{"PCTCompile - Progress Code Compiler", "0 file(s) compiled"});
+        expectLog("test1", new String[]{ //
+                "PCTCompile - Progress Code Compiler", //
+                "0 file(s) compiled"});
 
         // Touch test.p
-        expectLog("test2", new String[]{"[PCTCompile] PCTCompile - Progress Code Compiler", //
-            "[PCTCompile] test.p [R-code older than source]", //
-            "[PCTCompile] 2023-02-28T09:44:40.000 : rcode test.r", //
-            "[PCTCompile] 2023-02-28T09:44:49.000 : source:test.p", //
-            "[PCTCompile] test2.p [R-code older than source]", //
-            "[PCTCompile] 2023-02-28T09:44:40.000 : rcode test2.r", //
-            "[PCTCompile] 2023-02-28T09:44:49.000 : source:test2.p", //
-            "[PCTCompile] 2 file(s) compiled"
-            });
+        expectLog("test2", new String[]{ //
+                "PCTCompile - Progress Code Compiler", //
+                "test.p [R-code older than source]", //
+                "2023-02-28T09:44:40.000 : rcode test.r", //
+                "2023-02-28T09:44:49.000 : source:test.p", //
+                "test2.p [R-code older than source]", //
+                "2023-02-28T09:44:40.000 : rcode test2.r", //
+                "2023-02-28T09:44:49.000 : source:test2.p", //
+                "2 file(s) compiled"});
         // Touch test.i
-        expectLog("test3", new String[]{"[PCTCompile] PCTCompile - Progress Code Compiler", //
-            "[PCTCompile] test.p [R-code older than include file: test.i]", //
-            "[PCTCompile] 2023-02-28T09:44:49.000 : rcode build\test.r", //
-            "[PCTCompile] 2023-02-28T09:48:47.000 : include:src\test.i", //
-            "[PCTCompile] test2.p [R-code older than include file: test2.i]", //
-            "[PCTCompile] 2023-02-28T09:44:49.000 : rcode build\test2.r", //
-            "[PCTCompile] 2023-02-28T09:48:47.000 : include:src\test2.i", //
-            "[PCTCompile] 2 file(s) compiled"
-            });
+        expectLog("test3", new String[]{ //
+                "PCTCompile - Progress Code Compiler", //
+                "test.p [R-code older than include file: test.i]", //
+                "2023-02-28T09:44:49.000 : rcode build\test.r", //
+                "2023-02-28T09:48:47.000 : include:src\test.i", //
+                "test2.p [R-code older than include file: test2.i]", //
+                "2023-02-28T09:44:49.000 : rcode build\test2.r", //
+                "2023-02-28T09:48:47.000 : include:src\test2.i", //
+                "2 file(s) compiled"});
     }
 
 

--- a/src/test/com/phenix/pct/PCTCompileTest.java
+++ b/src/test/com/phenix/pct/PCTCompileTest.java
@@ -1727,6 +1727,41 @@ public class PCTCompileTest extends BuildFileTestNg {
         assertTrue(new File(BASEDIR, "test92/build3/item.r").exists());
     }
 
+    @Test(groups = {"v11"})
+    public void test93() {
+
+        configureProject(BASEDIR + "test93/build.xml");
+        // First build
+        expectLog("test1", new String[]{"PCTCompile - Progress Code Compiler", "test.p [No r-code]",
+                "test2.p [No r-code]", "2 file(s) compiled"});
+        // Second build, nothing compiled
+        expectLog("test1",
+                new String[]{"PCTCompile - Progress Code Compiler", "0 file(s) compiled"});
+
+        // Touch test.p
+        expectLog("test2", new String[]{"[PCTCompile] PCTCompile - Progress Code Compiler", //
+            "[PCTCompile] test.p [R-code older than source]", //
+            "[PCTCompile] 2023-02-28T09:44:40.000 : rcode test.r", //
+            "[PCTCompile] 2023-02-28T09:44:49.000 : source:test.p", //
+            "[PCTCompile] test2.p [R-code older than source]", //
+            "[PCTCompile] 2023-02-28T09:44:40.000 : rcode test2.r", //
+            "[PCTCompile] 2023-02-28T09:44:49.000 : source:test2.p", //
+            "[PCTCompile] 2 file(s) compiled"
+            });
+        // Touch test.i
+        expectLog("test3", new String[]{"[PCTCompile] PCTCompile - Progress Code Compiler", //
+            "[PCTCompile] test.p [R-code older than include file: test.i]", //
+            "[PCTCompile] 2023-02-28T09:44:49.000 : rcode build\test.r", //
+            "[PCTCompile] 2023-02-28T09:48:47.000 : include:src\test.i", //
+            "[PCTCompile] test2.p [R-code older than include file: test2.i]", //
+            "[PCTCompile] 2023-02-28T09:44:49.000 : rcode build\test2.r", //
+            "[PCTCompile] 2023-02-28T09:48:47.000 : include:src\test2.i", //
+            "[PCTCompile] 2 file(s) compiled"
+            });
+    }
+
+
+
     static final class Test80LineProcessor implements LineProcessor<Boolean> {
         private boolean rslt = true;
         private int numLines;

--- a/tests/PCTCompile/test93/build.xml
+++ b/tests/PCTCompile/test93/build.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<project name="PCTCompile-test93">
+  <taskdef resource="PCT.properties" />
+
+  <target name="test1">
+    <PCTCompile destDir="build" dlcHome="${DLC}" relativePaths="true" displayFiles="3">
+      <fileset dir="src" includes="*.p" />
+      <propath location="src" />
+      <Profiler description="PCTCompile-test93" enabled="${PROFILER}" coverage="true" outputDir="profiler" />
+    </PCTCompile>
+  </target>
+
+  <target name="test2">
+    <sleep milliseconds="1000" />
+    <touch file="src/test.p" />
+    <touch file="src/test2.p" />
+    <PCTCompile destDir="build" dlcHome="${DLC}" relativePaths="true" displayFiles="3">
+      <filelist dir="src" files="test.p,test2.p" />
+      <propath location="src" />
+      <Profiler description="PCTCompile-test93" enabled="${PROFILER}" coverage="true" outputDir="profiler" />
+    </PCTCompile>
+  </target>
+
+  <target name="test3">
+    <sleep milliseconds="1000" />
+    <touch file="src/test.i" />
+    <touch file="src/test2.i" />
+    <PCTCompile destDir="build" dlcHome="${DLC}" relativePaths="true" displayFiles="3">
+      <filelist dir="src" files="test.p,test2.p" />
+      <propath location="src" />
+      <Profiler description="PCTCompile-test93" enabled="${PROFILER}" coverage="true" outputDir="profiler" />
+    </PCTCompile>
+  </target>
+
+</project>

--- a/tests/PCTCompile/test93/src/test.i
+++ b/tests/PCTCompile/test93/src/test.i
@@ -1,0 +1,1 @@
+message "xyz".

--- a/tests/PCTCompile/test93/src/test.p
+++ b/tests/PCTCompile/test93/src/test.p
@@ -1,0 +1,2 @@
+{ test.i }
+message "hello".

--- a/tests/PCTCompile/test93/src/test2.i
+++ b/tests/PCTCompile/test93/src/test2.i
@@ -1,0 +1,1 @@
+message "xyz".

--- a/tests/PCTCompile/test93/src/test2.p
+++ b/tests/PCTCompile/test93/src/test2.p
@@ -1,0 +1,2 @@
+{ test2.i }
+message "hello".


### PR DESCRIPTION
minor marldown enhancements, fix VsCode markdown lint errors

# Description

Part I of a fix for #503, extra logging option to display the file timestamps

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix : removed potential side-effect by using local buffers for timestamps
- [ ] New feature : extra verbose displayFiles option 3
- [ ] This change requires a documentation update for the extra option

# Checklist:
- test shows an error that is AFAIK not related to my change
```
[testng] [main] ERROR org.prorefactor.proparse.ProparseErrorListener - Syntax error -- TestParseError.cls:12:13 -- Mismatched input 'method' expecting { PERIOD, SET }
[jacoco:coverage] Enhancing testng with coverage
   [testng] SLF4J: Class path contains multiple SLF4J bindings.
   [testng] SLF4J: Found binding in [jar:file:/C:/Users/cvb/git/pct/dist/PCT.jar!/org/slf4j/impl/StaticLoggerBinder.class]
   [testng] SLF4J: Found binding in [jar:file:/C:/Users/cvb/git/pct/lib/slf4j-simple-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
   [testng] SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
   [testng] The list of the cached namespaces:
   [testng] prefix DEFAULT: uri urn:schemas-progress-com:WSAD:0003
   [testng] prefix xsi: uri http://www.w3.org/2001/XMLSchema-instance
   [testng]
   [testng] ===============================================
   [testng] ${TESTENV} tests
   [testng] Total tests run: 417, Failures: 18, Skips: 0
   [testng] ===============================================
   [testng]
   [testng] The tests failed.
```
