### PR TITLE
Child class reliant on "LIKE" temp-table defined in parent does not compile incrementally after schema change

### DIFF
--- a/tests/PCTCompile/test94/build.xml
+++ b/tests/PCTCompile/test94/build.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<project name="PCTCompile-test89">
+  <taskdef resource="PCT.properties" />
+
+  <target name="init">
+    <mkdir dir="target/db" />
+    <sports2000 destDir="target/db" dbName="mydb" dlcHome="${DLC}" />
+  </target>
+
+  <target name="compile-and-run">
+    <mkdir dir="target/build" />
+    <PCTCompile destDir="target/build"
+                failOnError="false"
+                displayFiles="1"
+                dlcHome="${DLC}">
+      <DBConnection dbName="mydb" dbDir="target/db" readOnly="true" />
+      <propath location="src" />
+      <fileset dir="src" includes="**/*.cls,**/*.p" />
+    </PCTCompile>
+
+    <PCTRun procedure="runme.r"
+            dlcHome="${DLC}">
+      <DBConnection dbName="mydb" dbDir="target/db" readOnly="true" />
+      <propath location="target/build" />
+    </PCTRun>
+  </target>
+
+  <target name="dump-schema">
+    <!-- not used by test, but if you want to see the current schema run this to dump it -->
+    <PCTDumpSchema destfile="sports2000.df"
+                   tables="customer"
+                   dlcHome="${DLC}">
+      <DBConnection dbName="mydb" dbDir="target/db" readOnly="true" />
+    </PCTDumpSchema>
+  </target>
+
+  <target name="load-schema" >
+    <PCTLoadSchema dlcHome="${DLC}">
+      <DBConnection dbName="mydb" dbdir="target/db" singleUser="true" />
+      <fileset dir="." includes="incremental.df" />
+    </PCTLoadSchema>
+  </target>
+
+  <target name="test">
+    <antcall target="init" />
+    <antcall target="compile-and-run" />
+    <antcall target="load-schema" />
+    <antcall target="compile-and-run" />
+  </target>
+
+</project>

--- a/tests/PCTCompile/test94/incremental.df
+++ b/tests/PCTCompile/test94/incremental.df
@@ -1,0 +1,10 @@
+
+ADD FIELD "IncrementalField" OF "Customer" AS character
+  FORMAT "x(50)"
+  INITIAL ""
+  LABEL "IncrementalField"
+  POSITION 20
+  MAX-WIDTH 100
+  HELP ""
+  LENGTH 0
+  ORDER 201

--- a/tests/PCTCompile/test94/src/cls/someChildClass.cls
+++ b/tests/PCTCompile/test94/src/cls/someChildClass.cls
@@ -1,0 +1,12 @@
+class cls.someChildClass inherits cls.someClass:
+
+  method public void createRecordChild () :
+    create ttCustomer.
+    assign ttCustomer.someChar = "test".
+    release ttCustomer.
+
+    empty temp-table ttCustomer.
+    // parentMethodReliantOnSchema().
+  end method.
+
+end class.

--- a/tests/PCTCompile/test94/src/cls/someClass.cls
+++ b/tests/PCTCompile/test94/src/cls/someClass.cls
@@ -1,0 +1,28 @@
+class cls.someClass:
+
+  // {inc/ttTable.i}
+
+  define protected temp-table ttCustomer no-undo like customer
+    field newField as character
+    field someChar as character.
+
+  method public void createRecord () :
+    create ttCustomer.
+    assign ttCustomer.someChar = "some value 1".
+    release ttCustomer.
+  end method.
+
+  method public void parentMethodReliantOnSchema () :
+    create ttCustomer.
+    assign ttCustomer.newField = "some value 2".
+    release ttCustomer.
+  end method.
+
+  method public void displayRecord () :
+    message 100.
+    for first ttCustomer no-lock:
+      message 101 ttCustomer.someChar.
+    end.
+  end method.
+
+end class.

--- a/tests/PCTCompile/test94/src/runme.p
+++ b/tests/PCTCompile/test94/src/runme.p
@@ -1,0 +1,6 @@
+define variable someObj as class cls.someChildClass.
+
+someObj = new cls.someChildClass().
+
+message "runme successful!".
+return "0".


### PR DESCRIPTION
# Description

When compiling incrementally after a schema change child classes which are reliant on a temp-table defined in a parent class using the `LIKE` phrase do not re-compile.  When subsequently running the code we see the following error:

```log
   [PCTRun] TEMP-TABLE 'ttCustomer' of class 'cls.someChildClass' no longer matches the definition in base class 'cls.someClass'. (13203)
   [PCTRun] Could not access element 'ttCustomer' of class 'cls.someClass' using object of type 'cls.someChildClass' - caller compilation is out of sync with class compilation. (12882)
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My branch is started from the latest commit in main
- [ ] My commit history is clean
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
