### PR TITLE
ABLDuck - can't see all inherited methods with 3 level hierarchy 

### DIFF
--- a/src/java/za/co/mip/ablduck/ABLDuck.java
+++ b/src/java/za/co/mip/ablduck/ABLDuck.java
@@ -465,6 +465,7 @@ public class ABLDuck extends PCT {
         String inherits = curClass.inherits;
 
         if (!"".equals(inherits)) {
+            inherits = determineFullyQualifiedClassName(curClass.uses, inherits);
             result.addHierarchy(inherits);
 
             CompilationUnit nextClass = classes.get(inherits);

--- a/src/test/za/co/mip/ablduck/ABLDuckTest.java
+++ b/src/test/za/co/mip/ablduck/ABLDuckTest.java
@@ -182,6 +182,22 @@ public class ABLDuckTest extends BuildFileTestNg {
         assertEquals(js.implementations.size(), 1);
         assertEquals(js.implementations.get(0), "hierarchy.IFamily");
 
+        filename = "ABLDuck/test2/docs/output/classes/hierarchy.GrandSon.js";
+
+        content = new String(Files.readAllBytes(Paths.get(filename)));
+        content = content.substring(content.indexOf('(') + 1, content.length() - 2);
+
+        js = gson.fromJson(content, CompilationUnit.class);
+        assertEquals(js.superclasses.size(), 3);
+        assertEquals(js.superclasses.get(0), "hierarchy.Father");
+        assertEquals(js.superclasses.get(1), "hierarchy.Son");
+        assertEquals(js.superclasses.get(2), "hierarchy.GrandSon");
+        assertEquals(js.implementations.size(), 0);
+        assertEquals(js.members.get(4).id, "method-hierarchy_Father_HelloWorldFather");
+        assertEquals(js.members.get(4).tagname, "method");
+        assertEquals(js.members.get(4).owner, "hierarchy.Father");
+
+
         filename = "ABLDuck/test2/docs/output/classes/hierarchy.IFamily.js";
 
         content = new String(Files.readAllBytes(Paths.get(filename)));

--- a/tests/ABLDuck/test2/src/hierarchy/Father.cls
+++ b/tests/ABLDuck/test2/src/hierarchy/Father.cls
@@ -26,5 +26,17 @@ CLASS hierarchy.Father:
         RETURN.
 
     END METHOD.
+
+        /*------------------------------------------------------------------------------
+     Purpose: Say Hello from Father
+     Notes:
+         @param pName Name to say hello from father
+    ------------------------------------------------------------------------------*/
+
+    METHOD PUBLIC VOID HelloWorldFather ( INPUT pName AS CHARACTER  ):
+        
+        RETURN.
+
+    END METHOD.
  
 END CLASS.

--- a/tests/ABLDuck/test2/src/hierarchy/GrandSon.cls
+++ b/tests/ABLDuck/test2/src/hierarchy/GrandSon.cls
@@ -1,0 +1,30 @@
+ 
+ /*------------------------------------------------------------------------
+    File        : Son
+    Purpose     : THE GRAND SON
+    Syntax      : 
+    Description : 
+    Author(s)   : Han Solo
+    Created     : Mon Dec 02 16:34:10 CET 2019
+    Notes       : 
+  ----------------------------------------------------------------------*/
+
+
+USING hierarchy.Son FROM PROPATH.
+
+BLOCK-LEVEL ON ERROR UNDO, THROW.
+
+CLASS hierarchy.GrandSon INHERITS Son: 
+ 
+        /*------------------------------------------------------------------------------
+     Purpose: Say Hello from GrandSon
+     Notes:
+         @param pName Name to say hello from GrandSon
+    ------------------------------------------------------------------------------*/
+
+    METHOD PUBLIC VOID HelloWorldGrandSon ( INPUT pName AS CHARACTER  ):
+        
+        RETURN.
+
+    END METHOD.
+END CLASS.


### PR DESCRIPTION
# Description

With ABLDuck, if we have 3 level hierarchy (or more), inherited members are not visible in documentation because we don't have the full name in hierarchy.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My branch is started from the latest commit in main
- [x] My commit history is clean
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
