### PR TITLE
Refactor string null/empty checks

### DIFF
--- a/src/java/com/phenix/pct/GenericExecuteOptions.java
+++ b/src/java/com/phenix/pct/GenericExecuteOptions.java
@@ -548,7 +548,7 @@ public class GenericExecuteOptions implements IRunAttributes {
         }
 
         // Client mode
-        if (clientMode != null && !clientMode.isEmpty()) {
+        if (clientMode != null && !clientMode.trim().isEmpty()) {
             list.add("-" + clientMode);
         }
 
@@ -573,25 +573,25 @@ public class GenericExecuteOptions implements IRunAttributes {
         }
 
         // Stream code page
-        if (cpStream != null && !cpStream.isEmpty()) {
+        if (cpStream != null && !cpStream.trim().isEmpty()) {
             list.add("-cpstream"); //$NON-NLS-1$
             list.add(cpStream);
         }
 
         // Internal code page
-        if (cpInternal != null && !cpInternal.isEmpty()) {
+        if (cpInternal != null && !cpInternal.trim().isEmpty()) {
             list.add("-cpinternal"); //$NON-NLS-1$
             list.add(cpInternal);
         }
 
         // Collation table
-        if (cpColl != null && !cpColl.isEmpty()) {
+        if (cpColl != null && !cpColl.trim().isEmpty()) {
             list.add("-cpcoll"); //$NON-NLS-1$
             list.add(cpColl);
         }
 
         // Case table
-        if (cpCase != null && !cpCase.isEmpty()) {
+        if (cpCase != null && !cpCase.trim().isEmpty()) {
             list.add("-cpcase"); //$NON-NLS-1$
             list.add(cpCase);
         }
@@ -636,7 +636,7 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(ttBufferSize));
         }
 
-        if (numsep != null && !numsep.isEmpty()) {
+        if (numsep != null && !numsep.trim().isEmpty()) {
             int tmpSep = 0;
             try {
                 tmpSep = Integer.parseInt(numsep);
@@ -651,7 +651,7 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(tmpSep));
         }
 
-        if (numdec != null && !numdec.isEmpty()) {
+        if (numdec != null && !numdec.trim().isEmpty()) {
             int tmpDec = 0;
             try {
                 tmpDec = Integer.parseInt(numdec);
@@ -666,13 +666,13 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(tmpDec));
         }
 
-        if ((dateFormat != null) && (dateFormat.trim().length() > 0)) {
+        if ((dateFormat != null) && !dateFormat.trim().isEmpty()) {
             list.add("-d");
             list.add(dateFormat.trim());
         }
 
         // Parameter
-        if ((parameter != null) && !parameter.isEmpty()) {
+        if ((parameter != null) && !parameter.trim().isEmpty()) {
             list.add("-param"); //$NON-NLS-1$
             list.add(parameter);
         }

--- a/src/java/com/phenix/pct/GenericExecuteOptions.java
+++ b/src/java/com/phenix/pct/GenericExecuteOptions.java
@@ -548,7 +548,7 @@ public class GenericExecuteOptions implements IRunAttributes {
         }
 
         // Client mode
-        if (clientMode != null) {
+        if (clientMode != null && !clientMode.isEmpty()) {
             list.add("-" + clientMode);
         }
 
@@ -573,25 +573,25 @@ public class GenericExecuteOptions implements IRunAttributes {
         }
 
         // Stream code page
-        if (cpStream != null) {
+        if (cpStream != null && !cpStream.isEmpty()) {
             list.add("-cpstream"); //$NON-NLS-1$
             list.add(cpStream);
         }
 
         // Internal code page
-        if (cpInternal != null) {
+        if (cpInternal != null && !cpInternal.isEmpty()) {
             list.add("-cpinternal"); //$NON-NLS-1$
             list.add(cpInternal);
         }
 
         // Collation table
-        if (cpColl != null) {
+        if (cpColl != null && !cpColl.isEmpty()) {
             list.add("-cpcoll"); //$NON-NLS-1$
             list.add(cpColl);
         }
 
         // Case table
-        if (cpCase != null) {
+        if (cpCase != null && !cpCase.isEmpty()) {
             list.add("-cpcase"); //$NON-NLS-1$
             list.add(cpCase);
         }
@@ -636,7 +636,7 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(ttBufferSize));
         }
 
-        if (numsep != null) {
+        if (numsep != null && !numsep.isEmpty()) {
             int tmpSep = 0;
             try {
                 tmpSep = Integer.parseInt(numsep);
@@ -651,7 +651,7 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(tmpSep));
         }
 
-        if (numdec != null) {
+        if (numdec != null && !numdec.isEmpty()) {
             int tmpDec = 0;
             try {
                 tmpDec = Integer.parseInt(numdec);

--- a/src/test/com/phenix/pct/test/PCTRunTest.java
+++ b/src/test/com/phenix/pct/test/PCTRunTest.java
@@ -480,7 +480,7 @@ public class PCTRunTest extends BuildFileTestNg {
     public void test52() {
         configureProject("PCTRun/test52/build.xml");
         expectLog("test1", "----");
-        expectLog("test2", "-- --");
+        expectLog("test2", "----");
         expectLog("test3", "--xx--");
     }
 


### PR DESCRIPTION
Only add clientMode, cpstream, cpinternal, cpcoll, cpcase, numsep and numdec when they are not empty (""). This allows to create a generic build script where these attributes are always specified (as "" since you can't specify these as null).
Some attributes already had similar checks in place (e.g. "parameter" and dateFormat), but the way to check for empty string isn't uniform (sometimes isEmpty() is used, sometimes .trim.length() <> 0 is used).

There are more candidates to adjust (e.g. paramFile, tempDir etc.),  but these need other changes as these are not strings but Files (and my experience with Java is limited...)
