### PR TITLE
Allow blank iniFile and paramFile parameters

### DIFF
--- a/src/java/com/phenix/pct/GenericExecuteOptions.java
+++ b/src/java/com/phenix/pct/GenericExecuteOptions.java
@@ -548,7 +548,7 @@ public class GenericExecuteOptions implements IRunAttributes {
         }
 
         // Client mode
-        if (clientMode != null && !clientMode.isEmpty()) {
+        if (clientMode != null && !clientMode.trim().isEmpty()) {
             list.add("-" + clientMode);
         }
 
@@ -573,25 +573,25 @@ public class GenericExecuteOptions implements IRunAttributes {
         }
 
         // Stream code page
-        if (cpStream != null && !cpStream.isEmpty()) {
+        if (cpStream != null && !cpStream.trim().isEmpty()) {
             list.add("-cpstream"); //$NON-NLS-1$
             list.add(cpStream);
         }
 
         // Internal code page
-        if (cpInternal != null && !cpInternal.isEmpty()) {
+        if (cpInternal != null && !cpInternal.trim().isEmpty()) {
             list.add("-cpinternal"); //$NON-NLS-1$
             list.add(cpInternal);
         }
 
         // Collation table
-        if (cpColl != null && !cpColl.isEmpty()) {
+        if (cpColl != null && !cpColl.trim().isEmpty()) {
             list.add("-cpcoll"); //$NON-NLS-1$
             list.add(cpColl);
         }
 
         // Case table
-        if (cpCase != null && !cpCase.isEmpty()) {
+        if (cpCase != null && !cpCase.trim().isEmpty()) {
             list.add("-cpcase"); //$NON-NLS-1$
             list.add(cpCase);
         }
@@ -636,7 +636,7 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(ttBufferSize));
         }
 
-        if (numsep != null && !numsep.isEmpty()) {
+        if (numsep != null && !numsep.trim().isEmpty()) {
             int tmpSep = 0;
             try {
                 tmpSep = Integer.parseInt(numsep);
@@ -651,7 +651,7 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(tmpSep));
         }
 
-        if (numdec != null && !numdec.isEmpty()) {
+        if (numdec != null && !numdec.trim().isEmpty()) {
             int tmpDec = 0;
             try {
                 tmpDec = Integer.parseInt(numdec);
@@ -666,13 +666,13 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(tmpDec));
         }
 
-        if ((dateFormat != null) && (dateFormat.trim().length() > 0)) {
+        if ((dateFormat != null) && !dateFormat.trim().isEmpty()) {
             list.add("-d");
             list.add(dateFormat.trim());
         }
 
         // Parameter
-        if ((parameter != null) && !parameter.isEmpty()) {
+        if ((parameter != null) && !parameter.trim().isEmpty()) {
             list.add("-param"); //$NON-NLS-1$
             list.add(parameter);
         }

--- a/src/java/com/phenix/pct/GenericExecuteOptions.java
+++ b/src/java/com/phenix/pct/GenericExecuteOptions.java
@@ -183,7 +183,7 @@ public class GenericExecuteOptions implements IRunAttributes {
 
     @Override
     public void setIniFile(File iniFile) {
-        if (iniFile == null)
+        if (iniFile == null || iniFile.getPath().trim().isEmpty())
             return;
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             if (!iniFile.equals(parent.getProject().resolveFile(""))) {
@@ -408,7 +408,7 @@ public class GenericExecuteOptions implements IRunAttributes {
     public String getCpCase() {
         return cpCase;
     }
-    
+
     public String getCpColl() {
         return cpColl;
     }
@@ -520,7 +520,7 @@ public class GenericExecuteOptions implements IRunAttributes {
     protected void checkConfig() {
         boolean noProc = (procedure == null) || procedure.trim().isEmpty();
         boolean noClass = (className == null) || className.trim().isEmpty();
-        if (noProc && noClass) 
+        if (noProc && noClass)
             throw new BuildException("No procedure or className attribute");
         if (!noProc && !noClass)
             throw new BuildException("Procedure and className attributes are mutually exclusive");
@@ -532,7 +532,7 @@ public class GenericExecuteOptions implements IRunAttributes {
         List<String> list = new ArrayList<>();
 
         // Parameter file
-        if (paramFile != null) {
+        if (paramFile != null && !paramFile.getPath().trim().isEmpty()) {
             list.add("-pf"); //$NON-NLS-1$
             list.add(paramFile.getAbsolutePath());
         }
@@ -712,7 +712,7 @@ public class GenericExecuteOptions implements IRunAttributes {
 
     /**
      * Returns list of database connections, from dbConnList and dbConnSet
-     * 
+     *
      * @return List of PCTConnection objects. Empty list if no DB connections
      */
     public Collection<PCTConnection> getDBConnections() {
@@ -750,7 +750,7 @@ public class GenericExecuteOptions implements IRunAttributes {
 
     /**
      * Returns list of command line options.
-     * 
+     *
      * @return List of PCTRunOption objects. Empty list if no options.
      */
     public List<PCTRunOption> getOptions() {
@@ -759,7 +759,7 @@ public class GenericExecuteOptions implements IRunAttributes {
 
     /**
      * Returns list of parameters passed to the called Progress procedure.
-     * 
+     *
      * @return List of RunParameters objects. Empty list if no parameter.
      */
     public List<RunParameter> getParameters() {
@@ -768,7 +768,7 @@ public class GenericExecuteOptions implements IRunAttributes {
 
     /**
      * Returns list of output parameters to be filled by the called Progress procedure.
-     * 
+     *
      * @return List of OutputParameter objects. Empty list if no parameter.
      */
     public List<OutputParameter> getOutputParameters() {
@@ -781,7 +781,7 @@ public class GenericExecuteOptions implements IRunAttributes {
 
     /**
      * Creates a new Path instance
-     * 
+     *
      * @return Path
      */
     public Path createPropath() {

--- a/src/java/com/phenix/pct/GenericExecuteOptions.java
+++ b/src/java/com/phenix/pct/GenericExecuteOptions.java
@@ -548,7 +548,7 @@ public class GenericExecuteOptions implements IRunAttributes {
         }
 
         // Client mode
-        if (clientMode != null) {
+        if (clientMode != null && !clientMode.isEmpty()) {
             list.add("-" + clientMode);
         }
 
@@ -573,25 +573,25 @@ public class GenericExecuteOptions implements IRunAttributes {
         }
 
         // Stream code page
-        if (cpStream != null) {
+        if (cpStream != null && !cpStream.isEmpty()) {
             list.add("-cpstream"); //$NON-NLS-1$
             list.add(cpStream);
         }
 
         // Internal code page
-        if (cpInternal != null) {
+        if (cpInternal != null && !cpInternal.isEmpty()) {
             list.add("-cpinternal"); //$NON-NLS-1$
             list.add(cpInternal);
         }
 
         // Collation table
-        if (cpColl != null) {
+        if (cpColl != null && !cpColl.isEmpty()) {
             list.add("-cpcoll"); //$NON-NLS-1$
             list.add(cpColl);
         }
 
         // Case table
-        if (cpCase != null) {
+        if (cpCase != null && !cpCase.isEmpty()) {
             list.add("-cpcase"); //$NON-NLS-1$
             list.add(cpCase);
         }
@@ -636,7 +636,7 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(ttBufferSize));
         }
 
-        if (numsep != null) {
+        if (numsep != null && !numsep.isEmpty()) {
             int tmpSep = 0;
             try {
                 tmpSep = Integer.parseInt(numsep);
@@ -651,7 +651,7 @@ public class GenericExecuteOptions implements IRunAttributes {
             list.add(Integer.toString(tmpSep));
         }
 
-        if (numdec != null) {
+        if (numdec != null && !numdec.isEmpty()) {
             int tmpDec = 0;
             try {
                 tmpDec = Integer.parseInt(numdec);

--- a/src/test/com/phenix/pct/test/PCTRunTest.java
+++ b/src/test/com/phenix/pct/test/PCTRunTest.java
@@ -480,7 +480,7 @@ public class PCTRunTest extends BuildFileTestNg {
     public void test52() {
         configureProject("PCTRun/test52/build.xml");
         expectLog("test1", "----");
-        expectLog("test2", "-- --");
+        expectLog("test2", "----");
         expectLog("test3", "--xx--");
     }
 


### PR DESCRIPTION
In the same veign as previous PR, this allows to specify a default value of "" for iniFile/paramFile when creating a generic build.xml script.
Current workaround is to create an "empty.pf" and specify that one as default fallback.
For ini files it seems files not found are ignored, but we shouldn't log an `"Unable to find INI file " + iniFile.getAbsolutePath() + " - Skipping attribute"` message when the file path is blank.

For some reason this PR seems to include the already merged changes from previous PR, although I have based my new PR on the updated main branch...